### PR TITLE
Fix Norwegian timezone for 00:01/23:59 searches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2253,6 +2253,11 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "commander": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
+    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -2469,6 +2474,22 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.11.0.tgz",
       "integrity": "sha512-8P1cDi8ebZyDxUyUprBXwidoEtiQAawYPGvpfb+Dg0G6JrQ+VozwOmm91xYC0vAv1+0VmLehEPb+isg4BGUFfA=="
+    },
+    "date-fns-timezone": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/date-fns-timezone/-/date-fns-timezone-0.1.4.tgz",
+      "integrity": "sha512-npnZn1eIeHV8A3Hqw86mn6CjH+qMe0TSCs4anpD4Rouf+mE9eIJuaHviIpNmGL9GiDmcUoiaKdkX5ihf+yZQZA==",
+      "requires": {
+        "date-fns": "^1.29.0",
+        "timezone-support": "^1.5.5"
+      },
+      "dependencies": {
+        "date-fns": {
+          "version": "1.30.1",
+          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+          "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
+        }
+      }
     },
     "debug": {
       "version": "2.6.9",
@@ -8062,6 +8083,14 @@
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
       "dev": true
+    },
+    "timezone-support": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/timezone-support/-/timezone-support-1.8.1.tgz",
+      "integrity": "sha512-+pKzxoUe4PZXaQcswceJlA+69oRyyu1uivnYKdpsC7eGzZiuvTLbU4WYPqTKslEsoSvjN8k/u/6qNfGikBB/wA==",
+      "requires": {
+        "commander": "2.19.0"
+      }
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "date-fns": "^2.11.0",
+    "date-fns-timezone": "^0.1.4",
     "express": "^4.17.1",
     "lz-string": "^1.4.4",
     "winston": "^3.2.1"


### PR DESCRIPTION
Det siste søket me gjer ved ingen resultat, har me satt til 00:01/23:59 zulu-tid, som med sommartid blir 02:01/01:59 norsk tid. Dette blir feil, då Journey Planner sine tjenestedøgn opererer med norsk tid. 

Feil:
![image](https://user-images.githubusercontent.com/4339443/78227191-31275380-74cd-11ea-9ac4-16f173c57895.png)

Fixed:
![image](https://user-images.githubusercontent.com/4339443/78228207-ae06fd00-74ce-11ea-8586-851141f78f64.png)

[convertToTimeZone](https://github.com/prantlf/date-fns-timezone/blob/master/docs/API.md#converttotimezone) kan man berre bruke getterene til, tydeligvis, ifølge dokumentasjonen. Så eg lagde eit nytt date-objekt med samme dato, og så trekte frå tidssone-offseten. 

Det ser ikkje ut til at det går an å endre system-tidssone på App Engine.