### PR TITLE
Make /non-transit calls to JourneyPlanner, /transit through Offers

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,3 +1,5 @@
 ENVIRONMENT=dev
-JOURNEY_PLANNER_HOST=https://api.dev.entur.io/sales/v1/offers/search
-JOURNEY_PLANNER_V3_HOST=https://api.dev.entur.io/journey-planner/v3
+TRANSIT_HOST=https://api.dev.entur.io/sales/v1/offers/search
+NON_TRANSIT_HOST=https://api.dev.entur.io/journey-planner/v2
+TRANSIT_HOST_OTP2=https://api.dev.entur.io/journey-planner/v3
+NON_TRANSIT_HOST_OTP2=https://api.dev.entur.io/journey-planner/v3

--- a/.env.prod
+++ b/.env.prod
@@ -1,3 +1,5 @@
 ENVIRONMENT=prod
-JOURNEY_PLANNER_HOST=https://api.entur.io/sales/v1/offers/search
-JOURNEY_PLANNER_V3_HOST=https://api.staging.entur.io/journey-planner/v3
+TRANSIT_HOST=https://api.entur.io/sales/v1/offers/search
+NON_TRANSIT_HOST=https://api.entur.io/journey-planner/v2
+TRANSIT_HOST_OTP2=https://api.staging.entur.io/journey-planner/v3
+NON_TRANSIT_HOST_OTP2=https://api.staging.entur.io/journey-planner/v3

--- a/.env.staging
+++ b/.env.staging
@@ -1,3 +1,5 @@
 ENVIRONMENT=staging
-JOURNEY_PLANNER_HOST=https://api.staging.entur.io/sales/v1/offers/search
-JOURNEY_PLANNER_V3_HOST=https://api.staging.entur.io/journey-planner/v3
+TRANSIT_HOST=https://api.staging.entur.io/sales/v1/offers/search
+NON_TRANSIT_HOST=https://api.staging.entur.io/journey-planner/v2
+TRANSIT_HOST_OTP2=https://api.staging.entur.io/journey-planner/v3
+NON_TRANSIT_HOST_OTP2=https://api.staging.entur.io/journey-planner/v3

--- a/populateEnvVars.ts
+++ b/populateEnvVars.ts
@@ -58,7 +58,7 @@ async function replaceEnvVariables(): Promise<void> {
     const config = await readEnvFile()
     const filePaths = await getFiles('dist')
     const patterns: ReplacePattern[] = Object.entries(config).map(([name, value]) => [
-        new RegExp(`process.env.${name}`, 'g'),
+        new RegExp(`process.env.${name}\\W`, 'g'),
         `'${value}'`,
     ])
     await Promise.all(filePaths.map((path) => findAndReplaceInFile(path, patterns)))

--- a/src/otp1/controller.ts
+++ b/src/otp1/controller.ts
@@ -16,10 +16,17 @@ import {
 } from '../utils/tripPattern'
 import { sortBy } from '../utils/array'
 
-const sdk = createEnturService({
+const sdkTransit = createEnturService({
     clientName: 'entur-search',
     hosts: {
-        journeyPlanner: process.env.JOURNEY_PLANNER_HOST,
+        journeyPlanner: process.env.TRANSIT_HOST,
+    },
+})
+
+const sdkNonTransit = createEnturService({
+    clientName: 'entur-search',
+    hosts: {
+        journeyPlanner: process.env.NON_TRANSIT_HOST,
     },
 })
 
@@ -65,7 +72,7 @@ export async function searchTransit(
         maxPreTransitWalkDistance: 2000,
     }
 
-    const response = await sdk.getTripPatterns(getTripPatternsParams, { headers: extraHeaders })
+    const response = await sdkTransit.getTripPatterns(getTripPatternsParams, { headers: extraHeaders })
 
     const query = getTripPatternsQuery(getTripPatternsParams)
     const queries = [...(prevQueries || []), query]
@@ -95,7 +102,7 @@ export async function searchNonTransit(
 ): Promise<NonTransitTripPatterns> {
     const results = await Promise.all(
         modes.map(async (mode) => {
-            const result = await sdk.getTripPatterns(
+            const result = await sdkNonTransit.getTripPatterns(
                 {
                     ...params,
                     limit: mode === 'bicycle_rent' ? 3 : 1,
@@ -148,7 +155,7 @@ async function searchTaxiFrontBack(
 
     const [pickup, dropoff] = await Promise.all(
         modes.map(async (mode) => {
-            const response = await sdk.getTripPatterns(
+            const response = await sdkTransit.getTripPatterns(
                 {
                     ...searchParams,
                     limit: 1,

--- a/src/otp2/controller.ts
+++ b/src/otp2/controller.ts
@@ -20,7 +20,7 @@ import JOURNEY_PLANNER_QUERY from './query'
 const sdk = createEnturService({
     clientName: 'entur-search',
     hosts: {
-        journeyPlanner: process.env.JOURNEY_PLANNER_V3_HOST,
+        journeyPlanner: process.env.TRANSIT_HOST_OTP2,
     },
 })
 


### PR DESCRIPTION
Allows setting separate hosts for transit and non-transit calls through environment variables. 

We don't need to make non-transit calls through Offers, as we never ask for offers for these trip patterns.