### PR TITLE
Log statusCode in Response logger, use appropriate level

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -58,7 +58,19 @@ export function reqResLoggerMiddleware(req: Request, res: Response, next: NextFu
         originalResEnd.call(res, chunk, ...rest)
         res.end = originalResEnd
 
-        logger.info(`Response ${req.method} ${req.url}`, {
+        let level = 'info'
+
+        if (res.statusCode >= 400) {
+            level = 'warn'
+        }
+
+        if (res.statusCode >= 500) {
+            level = 'error'
+        }
+
+        logger.log({
+            level,
+            message: `Response ${res.statusCode} ${req.method} ${req.url}`,
             req: {
                 headers: reqHeadersMapper(req),
             },


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4339443/80972657-a9f83300-8e1e-11ea-84a2-fb828f608a99.png)

* Status code < 400 is info
* Status code  >= 400, < 500 is warn
* Status code >= 400 is error

