### PR TITLE
Retry BigQuery queries if rate limit exceeded

### DIFF
--- a/src/utils/promise.ts
+++ b/src/utils/promise.ts
@@ -1,0 +1,3 @@
+export function sleep(duration: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, duration))
+}


### PR DESCRIPTION
Fixes these:

![image](https://user-images.githubusercontent.com/4339443/81191596-7b628f80-8fb9-11ea-9101-5ee03b07b748.png)

If rate limit exceeded, query is retried with randomized exponential backoff, max 3 retries.