### PR TITLE
Restrict useflex to inital search only

### DIFF
--- a/src/otp1/controller.ts
+++ b/src/otp1/controller.ts
@@ -68,7 +68,6 @@ export async function searchTransit(
 
     const getTripPatternsParams = {
         ...searchParams,
-        useFlex: true,
         maxPreTransitWalkDistance: 2000,
     }
 

--- a/src/otp1/index.ts
+++ b/src/otp1/index.ts
@@ -57,6 +57,7 @@ function getParams(params: RawSearchParams): SearchParams {
         transportSubmodes: subModesFilter,
         banned,
         whiteListed,
+        useFlex: true,
     }
 }
 
@@ -68,6 +69,11 @@ router.post('/v1/transit', async (req, res, next) => {
 
         const params = cursorData?.params || getParams(req.body)
         const extraHeaders = getHeadersFromClient(req)
+
+        if (cursorData) {
+            // Restrict flex results only to the initial search
+            params.useFlex = false
+        }
 
         stopTrace = trace(cursorData ? 'searchTransit' : 'searchTransitWithTaxi')
         const { tripPatterns, hasFlexibleTripPattern, isSameDaySearch, queries } = cursorData


### PR DESCRIPTION
If every continued search uses useFlex true, we get duplicate results with 1 min diff