### PR TITLE
Move secrets that are not secrets to env files

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -5,3 +5,5 @@ TRANSIT_HOST_OTP2=https://api.dev.entur.io/journey-planner/v3
 NON_TRANSIT_HOST_OTP2=https://api.dev.entur.io/journey-planner/v3
 REDIS_HOST=10.127.131.91
 REDIS_PORT=6379
+PARTNER_AUDIENCE=https://api.dev.entur.io
+PARTNER_HOST=https://partner.dev.entur.org

--- a/.env.prod
+++ b/.env.prod
@@ -5,3 +5,5 @@ TRANSIT_HOST_OTP2=https://api.staging.entur.io/journey-planner/v3
 NON_TRANSIT_HOST_OTP2=https://api.staging.entur.io/journey-planner/v3
 REDIS_HOST=10.123.137.187
 REDIS_PORT=6379
+PARTNER_AUDIENCE=https://api.entur.io
+PARTNER_HOST=https://partner.entur.org

--- a/.env.staging
+++ b/.env.staging
@@ -5,3 +5,5 @@ TRANSIT_HOST_OTP2=https://api.staging.entur.io/journey-planner/v3
 NON_TRANSIT_HOST_OTP2=https://api.staging.entur.io/journey-planner/v3
 REDIS_HOST=10.221.223.59
 REDIS_PORT=6379
+PARTNER_AUDIENCE=https://api.staging.entur.io
+PARTNER_HOST=https://partner.staging.entur.org

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,3 @@
 node_modules
 dist
 search-endpoints.txt
-
-.secrets*


### PR DESCRIPTION
Partner audience and host are not secret. Therefore, we can move them to checked-in .env files.

`npm run dev` crashed if `dist` did not exist. Fixed it with fs.mkdir recursive.