### PR TITLE
OTP switch on search parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 node_modules
 dist
 search-endpoints.txt
+dump.rdb

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -4,9 +4,10 @@ import { promisify } from 'util'
 import logger from './logger'
 import { REDIS_HOST, REDIS_PORT } from './config'
 
-const DEV = process.env.NODE_ENV === 'development'
-const host = DEV ? 'localhost' : REDIS_HOST
-const port = DEV ? 6379 : Number(REDIS_PORT)
+const PROD = process.env.NODE_ENV === 'production'
+
+const host = PROD ? REDIS_HOST : 'localhost'
+const port = PROD ? Number(REDIS_PORT) : 6379
 
 const client = redis.createClient(port, host)
 

--- a/src/otp1/controller.ts
+++ b/src/otp1/controller.ts
@@ -89,7 +89,6 @@ export async function searchTransit(
     return {
         tripPatterns,
         hasFlexibleTripPattern: tripPatterns.some(isFlexibleAlternative),
-        isSameDaySearch, // TODO 2020-03-09: Deprecated! For compatibility with v5.2.0 and older app versions we need to keep returning isSameDaySearch for a while. See https://bitbucket.org/enturas/entur-clients/pull-requests/4167
         queries,
     }
 }

--- a/src/otp2/controller.ts
+++ b/src/otp2/controller.ts
@@ -10,7 +10,7 @@ import createEnturService, {
 import { differenceInHours } from 'date-fns'
 import { v4 as uuid } from 'uuid'
 
-import { SearchParams, NonTransitTripPatterns, GraphqlQuery } from '../../types'
+import { SearchParams, NonTransitTripPatterns, GraphqlQuery, Metadata } from '../../types'
 
 import { isFlexibleAlternative, isValidTransitAlternative } from '../utils/tripPattern'
 
@@ -38,6 +38,7 @@ interface TransitTripPatterns {
     tripPatterns: Otp2TripPattern[]
     hasFlexibleTripPattern: boolean
     queries: GraphqlQuery[]
+    metadata?: Metadata
 }
 
 function parseTripPattern(rawTripPattern: any): Otp2TripPattern {
@@ -150,12 +151,6 @@ export function legMapper(leg: Leg): Leg {
     }
 }
 
-export interface Metadata {
-    searchWindowUsed: number
-    nextDateTime: string
-    prevDateTime: string
-}
-
 async function getTripPatterns(params: any): Promise<[Otp2TripPattern[], Metadata | undefined]> {
     const res = await sdk.queryJourneyPlanner<{
         trip: { metadata: Metadata; tripPatterns: any[] }
@@ -176,7 +171,7 @@ export async function searchTransit(
     params: SearchParams,
     extraHeaders: { [key: string]: string },
     prevQueries?: GraphqlQuery[],
-): Promise<TransitTripPatterns & { metadata?: Metadata }> {
+): Promise<TransitTripPatterns> {
     const { initialSearchDate, searchFilter, ...searchParams } = params
     const { searchDate } = searchParams
 

--- a/src/otp2/cursor.ts
+++ b/src/otp2/cursor.ts
@@ -5,8 +5,7 @@ import { TripPattern } from '@entur/sdk'
 
 import { isTransitAlternative, isFlexibleAlternative } from '../utils/tripPattern'
 
-import { CursorData, SearchParams } from '../../types'
-import { Metadata } from './controller'
+import { CursorData, SearchParams, Metadata } from '../../types'
 
 export function parseCursor(cursor?: string): CursorData | undefined {
     if (!cursor?.length) return undefined

--- a/src/otp2/index.ts
+++ b/src/otp2/index.ts
@@ -32,7 +32,7 @@ function getHeadersFromClient(req: Request): ExtraHeaders {
     })
 }
 
-function generateShamashLink({ query, variables }: GraphqlQuery): string {
+export function generateShamashLink({ query, variables }: GraphqlQuery): string {
     const host =
         ENVIRONMENT === 'prod'
             ? 'https://api.entur.io/graphql-explorer/journey-planner-v3'

--- a/src/tracer.ts
+++ b/src/tracer.ts
@@ -2,7 +2,7 @@ import { PluginTypes, start as startTracer } from '@google-cloud/trace-agent'
 
 let tracer: PluginTypes.Tracer
 
-if (startTracer) {
+if (startTracer && process.env.NODE_ENV === 'production') {
     tracer = startTracer()
 }
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -32,11 +32,17 @@ export interface GraphqlQuery {
     variables?: object
 }
 
+export interface Metadata {
+    searchWindowUsed: number
+    nextDateTime: string
+    prevDateTime: string
+}
+
 export interface TransitTripPatterns {
     tripPatterns: TripPattern[]
     hasFlexibleTripPattern: boolean
-    isSameDaySearch?: boolean
     queries: GraphqlQuery[]
+    metadata?: Metadata
 }
 
 export interface NonTransitTripPatterns {


### PR DESCRIPTION
Allow using OTP 2 for some transit searches based on the search parameters, for gradually phasing OTP 2 into production.

Starting with `false`: everything goes through OTP 1.