### PR TITLE
Use default Prettier printWidth of 80

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,5 +1,4 @@
 module.exports = {
-    printWidth: 120,
     trailingComma: 'all',
     tabWidth: 4,
     semi: false,

--- a/scripts/environment.ts
+++ b/scripts/environment.ts
@@ -49,7 +49,8 @@ async function createTypeDefinition(): Promise<void> {
 async function createConfigFile(): Promise<void> {
     try {
         const envConfig = await readEnvFile(ENV_FILE)
-        const format = ([key, value]: [string, string]): string => `exports.${key} = "${value}";`
+        const format = ([key, value]: [string, string]): string =>
+            `exports.${key} = "${value}";`
 
         const content = `"use strict";
     Object.defineProperty(exports, "__esModule", { value: true });

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -16,7 +16,12 @@ export const verifyPartnerToken = jwt({
     algorithms: ['RS256'],
 })
 
-export function unauthorizedError(error: Error, _req: Request, res: Response, next: NextFunction): void {
+export function unauthorizedError(
+    error: Error,
+    _req: Request,
+    res: Response,
+    next: NextFunction,
+): void {
     if (error.name === 'UnauthorizedError') {
         res.status(401).send(error.message)
         return

--- a/src/bigquery.ts
+++ b/src/bigquery.ts
@@ -15,12 +15,18 @@ const MAX_RETRIES = 5
 async function queryWithRetries(query: string, retriesDone = 0): Promise<void> {
     try {
         await bigQuery.query({ query, useLegacySql: false })
-        logger.debug(`logTransitAnalytics success, retries done: ${retriesDone}`)
+        logger.debug(
+            `logTransitAnalytics success, retries done: ${retriesDone}`,
+        )
     } catch (error) {
-        if (error.message.includes('Exceeded rate limits') && retriesDone < MAX_RETRIES) {
+        if (
+            error.message.includes('Exceeded rate limits') &&
+            retriesDone < MAX_RETRIES
+        ) {
             const retryNumber = retriesDone + 1
             const minDelay = 100 * retryNumber
-            const sleepDuration = minDelay + 2 ** retryNumber * 1000 * Math.random()
+            const sleepDuration =
+                minDelay + 2 ** retryNumber * 1000 * Math.random()
             await sleep(sleepDuration)
             return queryWithRetries(query, retryNumber)
         }
@@ -28,7 +34,10 @@ async function queryWithRetries(query: string, retriesDone = 0): Promise<void> {
     }
 }
 
-export async function logTransitAnalytics(params: SearchParams, headers: { [key: string]: string }): Promise<void> {
+export async function logTransitAnalytics(
+    params: SearchParams,
+    headers: { [key: string]: string },
+): Promise<void> {
     const client = headers['ET-Client-Name'] || ''
     const table = getTableForClient(client)
 
@@ -45,14 +54,18 @@ export async function logTransitAnalytics(params: SearchParams, headers: { [key:
             minimumTransferTime,
             useFlex = false,
         } = params
-        const searchDateParsed = searchDate ? `"${parseJSON(searchDate).toISOString()}"` : ''
+        const searchDateParsed = searchDate
+            ? `"${parseJSON(searchDate).toISOString()}"`
+            : ''
         const createdAt = new Date().toISOString()
 
         const query = `INSERT INTO \`${table}\` (
             fromName, fromPlace, toName, toPlace, searchDate, searchFilter,
             arriveBy, walkSpeed, minimumTransferTime, useFlex, createdAt
         ) VALUES (
-            "${from.name}", "${from.place}", "${to.name}", "${to.place}", ${searchDateParsed},
+            "${from.name}", "${from.place}", "${to.name}", "${
+            to.place
+        }", ${searchDateParsed},
             "${searchFilter.join()}", ${arriveBy}, ${walkSpeed}, ${minimumTransferTime}, ${useFlex},
             "${createdAt}"
         )`
@@ -65,6 +78,12 @@ export async function logTransitAnalytics(params: SearchParams, headers: { [key:
 
 function getTableForClient(client: string): string | undefined {
     if (ENVIRONMENT !== 'prod') return
-    if (client.startsWith('entur-client-app')) return 'entur-prod.analytics_app.transit_search'
-    if (client.startsWith('entur-client-web')) return 'entur-prod.analytics_web.transit_search'
+
+    if (client.startsWith('entur-client-app')) {
+        return 'entur-prod.analytics_app.transit_search'
+    }
+
+    if (client.startsWith('entur-client-web')) {
+        return 'entur-prod.analytics_web.transit_search'
+    }
 }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -19,7 +19,11 @@ const expire = promisify(client.expire).bind(client)
 
 const DEFAULT_EXPIRE = 30 * 60 // 30 minutes
 
-export async function set(key: string, value: any, expireInSeconds: number = DEFAULT_EXPIRE): Promise<void> {
+export async function set(
+    key: string,
+    value: any,
+    expireInSeconds: number = DEFAULT_EXPIRE,
+): Promise<void> {
     logger.debug(`Cache set ${key}`)
     await hset(key, 'data', JSON.stringify(value))
     await expire(key, expireInSeconds)

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -25,7 +25,8 @@ const loggingWinston = new LoggingWinston({
 const transportsDev = [new winston.transports.Console()]
 const transportsProd = [loggingWinston]
 
-const transports = process.env.NODE_ENV === 'production' ? transportsProd : transportsDev
+const transports =
+    process.env.NODE_ENV === 'production' ? transportsProd : transportsDev
 
 const logger = winston.createLogger({
     level: 'debug',
@@ -64,7 +65,11 @@ export function getTraceInfo(): object {
 }
 
 // Some inspiration taken from the express-winston library by bithavoc: https://github.com/bithavoc/express-winston/blob/master/index.js
-export function reqResLoggerMiddleware(req: Request, res: Response, next: NextFunction): void {
+export function reqResLoggerMiddleware(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+): void {
     const startTime = new Date()
     const { method, url } = req
 
@@ -101,7 +106,7 @@ export function reqResLoggerMiddleware(req: Request, res: Response, next: NextFu
                 }
 
                 if (response?.message) {
-                    message = `Response ${res.statusCode} ${req.method} ${req.url} – ${response?.message || ''}`
+                    message += ` – ${response?.message || ''}`
                 }
             }
         }

--- a/src/otp1/cursor.ts
+++ b/src/otp1/cursor.ts
@@ -1,10 +1,16 @@
-import { compressToEncodedURIComponent, decompressFromEncodedURIComponent } from 'lz-string'
+import {
+    compressToEncodedURIComponent,
+    decompressFromEncodedURIComponent,
+} from 'lz-string'
 import { addMinutes, subMinutes, parseJSON } from 'date-fns'
 
 import { TripPattern } from '@entur/sdk'
 
 import { maxBy, minBy } from '../utils/array'
-import { isTransitAlternative, isFlexibleAlternative } from '../utils/tripPattern'
+import {
+    isTransitAlternative,
+    isFlexibleAlternative,
+} from '../utils/tripPattern'
 
 import { CursorData, SearchParams } from '../../types'
 
@@ -27,7 +33,10 @@ export function parseCursor(cursor?: string): CursorData | undefined {
     }
 }
 
-export function generateCursor(params: SearchParams, tripPatterns: TripPattern[] = []): string | undefined {
+export function generateCursor(
+    params: SearchParams,
+    tripPatterns: TripPattern[] = [],
+): string | undefined {
     const { arriveBy } = params
     const hasTransitPatterns = tripPatterns.some(isTransitAlternative)
     const hasFlexiblePatterns = tripPatterns.some(isFlexibleAlternative)
@@ -40,7 +49,11 @@ export function generateCursor(params: SearchParams, tripPatterns: TripPattern[]
 
     const cursorData = {
         v: 1,
-        params: { ...params, searchDate: nextDate, useFlex: hasFlexiblePatterns },
+        params: {
+            ...params,
+            searchDate: nextDate,
+            useFlex: hasFlexiblePatterns,
+        },
     }
 
     return compressToEncodedURIComponent(JSON.stringify(cursorData))

--- a/src/otp2/cursor.ts
+++ b/src/otp2/cursor.ts
@@ -1,9 +1,15 @@
-import { compressToEncodedURIComponent, decompressFromEncodedURIComponent } from 'lz-string'
+import {
+    compressToEncodedURIComponent,
+    decompressFromEncodedURIComponent,
+} from 'lz-string'
 import { parseJSON } from 'date-fns'
 
 import { TripPattern } from '@entur/sdk'
 
-import { isTransitAlternative, isFlexibleAlternative } from '../utils/tripPattern'
+import {
+    isTransitAlternative,
+    isFlexibleAlternative,
+} from '../utils/tripPattern'
 
 import { CursorData, SearchParams, Metadata } from '../../types'
 
@@ -40,7 +46,11 @@ export function generateCursor(
 
     const cursorData = {
         v: 1,
-        params: { ...params, searchDate: nextDate, useFlex: hasFlexiblePatterns },
+        params: {
+            ...params,
+            searchDate: nextDate,
+            useFlex: hasFlexiblePatterns,
+        },
     }
 
     return compressToEncodedURIComponent(JSON.stringify(cursorData))

--- a/src/otp2/index.ts
+++ b/src/otp2/index.ts
@@ -32,7 +32,10 @@ function getHeadersFromClient(req: Request): ExtraHeaders {
     })
 }
 
-export function generateShamashLink({ query, variables }: GraphqlQuery): string {
+export function generateShamashLink({
+    query,
+    variables,
+}: GraphqlQuery): string {
     const host =
         ENVIRONMENT === 'prod'
             ? 'https://api.entur.io/graphql-explorer/journey-planner-v3'
@@ -42,8 +45,15 @@ export function generateShamashLink({ query, variables }: GraphqlQuery): string 
 }
 
 function getParams(params: RawSearchParams): SearchParams {
-    const searchDate = params.searchDate ? parseJSON(params.searchDate) : new Date()
-    const { filteredModes, subModesFilter, banned, whiteListed } = filterModesAndSubModes(params.searchFilter)
+    const searchDate = params.searchDate
+        ? parseJSON(params.searchDate)
+        : new Date()
+    const {
+        filteredModes,
+        subModesFilter,
+        banned,
+        whiteListed,
+    } = filterModesAndSubModes(params.searchFilter)
 
     return {
         ...params,
@@ -61,7 +71,12 @@ router.post('/v1/transit', async (req, res, next) => {
         const cursorData = parseCursor(req.body?.cursor)
         const params = cursorData?.params || getParams(req.body)
         const extraHeaders = getHeadersFromClient(req)
-        const { tripPatterns, hasFlexibleTripPattern, queries, metadata } = await searchTransit(params, extraHeaders)
+        const {
+            tripPatterns,
+            hasFlexibleTripPattern,
+            queries,
+            metadata,
+        } = await searchTransit(params, extraHeaders)
 
         const queriesWithLinks =
             ENVIRONMENT === 'prod'
@@ -73,7 +88,11 @@ router.post('/v1/transit', async (req, res, next) => {
 
         const nextCursor = generateCursor(params, metadata, tripPatterns)
 
-        await Promise.all(tripPatterns.map((tripPattern) => cacheSet(`trip-pattern:${tripPattern.id}`, tripPattern)))
+        await Promise.all(
+            tripPatterns.map((tripPattern) =>
+                cacheSet(`trip-pattern:${tripPattern.id}`, tripPattern),
+            ),
+        )
 
         res.json({
             tripPatterns,
@@ -94,7 +113,9 @@ router.get('/v1/trip-patterns/:id', async (req, res, next) => {
         const tripPattern = await cacheGet<TripPattern>(`trip-pattern:${id}`)
 
         if (!tripPattern) {
-            throw new NotFoundError(`Found no trip pattern with id ${id}. Maybe cache entry expired?`)
+            throw new NotFoundError(
+                `Found no trip pattern with id ${id}. Maybe cache entry expired?`,
+            )
         }
 
         if (update) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -39,18 +39,29 @@ app.all('*', (_, res) => {
 
 app.use(unauthorizedError)
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-app.use((error: Error, _req: express.Request, res: express.Response, _2: express.NextFunction) => {
-    const name = error.constructor?.name || 'Error'
-    let statusCode = 500
-    if (error instanceof NotFoundError) {
-        statusCode = 404
-    } else if (error instanceof InvalidArgumentError) {
-        statusCode = 400
-    }
+app.use(
+    (
+        error: Error,
+        _req: express.Request,
+        res: express.Response,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        _2: express.NextFunction,
+    ) => {
+        const name = error.constructor?.name || 'Error'
+        let statusCode = 500
+        if (error instanceof NotFoundError) {
+            statusCode = 404
+        } else if (error instanceof InvalidArgumentError) {
+            statusCode = 400
+        }
 
-    res.status(statusCode).json({ error: error.message, stack: error.stack, name })
-})
+        res.status(statusCode).json({
+            error: error.message,
+            stack: error.stack,
+            name,
+        })
+    },
+)
 
 app.listen(PORT, () => {
     // eslint-disable-next-line no-console

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,4 +1,8 @@
-export function sortBy<T, S>(list: T[], getValue: (x: T) => S, order: 'asc' | 'desc' = 'asc'): T[] {
+export function sortBy<T, S>(
+    list: T[],
+    getValue: (x: T) => S,
+    order: 'asc' | 'desc' = 'asc',
+): T[] {
     // eslint-disable-next-line fp/no-mutating-methods
     return [...list].sort((a, b) => {
         const valA = getValue(a)

--- a/src/utils/graphql.ts
+++ b/src/utils/graphql.ts
@@ -5,7 +5,11 @@ function minifiyGraphqlVariables(variables: { [key: string]: any }): string {
     return encodeURIComponent(JSON.stringify(variables))
 }
 
-export function buildShamashLink(host: string, query: string, variables?: { [key: string]: any }): string {
+export function buildShamashLink(
+    host: string,
+    query: string,
+    variables?: { [key: string]: any },
+): string {
     const minifiedQuery = minifiyGraphqlQuery(query)
     let url = `${host}?query=${minifiedQuery}`
 

--- a/src/utils/leg.test.ts
+++ b/src/utils/leg.test.ts
@@ -28,7 +28,9 @@ describe('parseLeg', () => {
 describe('isFlexibleLeg', () => {
     it('should check if the leg has a flexible line type', () => {
         const nonFlexibleLeg = { line: { flexibleLineType: undefined } } as Leg
-        const flexibleLeg = { line: { flexibleLineType: 'flexibleAreasOnly' } } as Leg
+        const flexibleLeg = {
+            line: { flexibleLineType: 'flexibleAreasOnly' },
+        } as Leg
 
         expect(isFlexibleLeg(nonFlexibleLeg)).toBeFalsy()
         expect(isFlexibleLeg(flexibleLeg)).toBeTruthy()
@@ -49,10 +51,27 @@ describe('isTransitLeg', () => {
 describe('isBikeRentalLeg', () => {
     it("should check if the leg's from- and to-places are bike rental stations", () => {
         const bikeStation = ({ bikeRentalStation: true } as unknown) as Place
-        const nonBikeStation = ({ bikeRentalStation: false } as unknown) as Place
+        const nonBikeStation = ({
+            bikeRentalStation: false,
+        } as unknown) as Place
 
-        expect(isBikeRentalLeg({ fromPlace: nonBikeStation, toPlace: bikeStation } as Leg)).toBeFalsy()
-        expect(isBikeRentalLeg({ fromPlace: bikeStation, toPlace: nonBikeStation } as Leg)).toBeFalsy()
-        expect(isBikeRentalLeg({ fromPlace: bikeStation, toPlace: bikeStation } as Leg)).toBeTruthy()
+        expect(
+            isBikeRentalLeg({
+                fromPlace: nonBikeStation,
+                toPlace: bikeStation,
+            } as Leg),
+        ).toBeFalsy()
+        expect(
+            isBikeRentalLeg({
+                fromPlace: bikeStation,
+                toPlace: nonBikeStation,
+            } as Leg),
+        ).toBeFalsy()
+        expect(
+            isBikeRentalLeg({
+                fromPlace: bikeStation,
+                toPlace: bikeStation,
+            } as Leg),
+        ).toBeTruthy()
     })
 })

--- a/src/utils/leg.ts
+++ b/src/utils/leg.ts
@@ -26,7 +26,9 @@ export function isTransitLeg({ mode }: Leg): boolean {
 }
 
 export function isBikeRentalLeg(leg: Leg): boolean {
-    return Boolean(leg.fromPlace?.bikeRentalStation && leg.toPlace?.bikeRentalStation)
+    return Boolean(
+        leg.fromPlace?.bikeRentalStation && leg.toPlace?.bikeRentalStation,
+    )
 }
 
 // Replaces `leg.mode` from the OTP result from `coach` to `bus`.

--- a/src/utils/modes.test.ts
+++ b/src/utils/modes.test.ts
@@ -9,19 +9,34 @@ import { ALL_BUS_SUBMODES, ALL_RAIL_SUBMODES } from '../constants'
 const flytogWhitelist = { authorities: ['FLT:Authority:FLT'] }
 
 function getBusFilter(filters: TransportSubmodeParam[]): TransportSubmodeParam {
-    return filters.find((filter) => filter.transportMode === LegMode.BUS) as TransportSubmodeParam
+    return filters.find(
+        (filter) => filter.transportMode === LegMode.BUS,
+    ) as TransportSubmodeParam
 }
 
-function getRailFilter(filters: TransportSubmodeParam[]): TransportSubmodeParam {
-    return filters.find((filter) => filter.transportMode === LegMode.RAIL) as TransportSubmodeParam
+function getRailFilter(
+    filters: TransportSubmodeParam[],
+): TransportSubmodeParam {
+    return filters.find(
+        (filter) => filter.transportMode === LegMode.RAIL,
+    ) as TransportSubmodeParam
 }
 
 describe('filterModesAndSubModes', () => {
     it('should include coach mode if bus mode is present', () => {
-        const modesWithBusWithoutCoach: SearchFilterType[] = ['rail', 'metro', 'bus', 'water']
+        const modesWithBusWithoutCoach: SearchFilterType[] = [
+            'rail',
+            'metro',
+            'bus',
+            'water',
+        ]
         const modesWithBusAndCoach: any = ['foot', 'bus', 'coach']
-        const { filteredModes: withoutCoach } = filterModesAndSubModes(modesWithBusWithoutCoach)
-        const { filteredModes: withCoach } = filterModesAndSubModes(modesWithBusAndCoach)
+        const { filteredModes: withoutCoach } = filterModesAndSubModes(
+            modesWithBusWithoutCoach,
+        )
+        const { filteredModes: withCoach } = filterModesAndSubModes(
+            modesWithBusAndCoach,
+        )
 
         expect(withoutCoach).toContain(LegMode.COACH)
         expect(withCoach).toEqual(expect.arrayContaining(modesWithBusAndCoach))
@@ -30,74 +45,139 @@ describe('filterModesAndSubModes', () => {
     it('should add foot if not included', () => {
         const modesWithoutFoot: any = ['bus', 'coach', 'metro', 'rail']
         const modesWithFoot: any = ['bus', 'coach', 'foot', 'metro', 'rail']
-        const { filteredModes: withFoot } = filterModesAndSubModes(modesWithoutFoot)
+        const { filteredModes: withFoot } = filterModesAndSubModes(
+            modesWithoutFoot,
+        )
         expect(withFoot).toEqual(expect.arrayContaining(modesWithFoot))
 
-        const { filteredModes: withNoDuplicateFoot } = filterModesAndSubModes(modesWithFoot)
+        const { filteredModes: withNoDuplicateFoot } = filterModesAndSubModes(
+            modesWithFoot,
+        )
         expect(withNoDuplicateFoot.length).toBe(modesWithFoot.length)
-        expect(withNoDuplicateFoot).toEqual(expect.arrayContaining(modesWithFoot))
+        expect(withNoDuplicateFoot).toEqual(
+            expect.arrayContaining(modesWithFoot),
+        )
     })
 
     it('should include bus mode and railReplacementBus sub mode if rail mode is present', () => {
-        const modesWithRailWithoutBus: SearchFilterType[] = ['rail', 'metro', 'air', 'water']
-        const { filteredModes, subModesFilter } = filterModesAndSubModes(modesWithRailWithoutBus)
+        const modesWithRailWithoutBus: SearchFilterType[] = [
+            'rail',
+            'metro',
+            'air',
+            'water',
+        ]
+        const { filteredModes, subModesFilter } = filterModesAndSubModes(
+            modesWithRailWithoutBus,
+        )
         const busFilter = getBusFilter(subModesFilter)
 
         expect(filteredModes).toContain(LegMode.BUS)
         expect(busFilter.transportMode).toEqual(LegMode.BUS)
-        expect(busFilter.transportSubmodes).toContain(TransportSubmode.RAIL_REPLACEMENT_BUS)
+        expect(busFilter.transportSubmodes).toContain(
+            TransportSubmode.RAIL_REPLACEMENT_BUS,
+        )
     })
 
     it('should include bus mode and railReplacementBus sub mode if flytog mode is present', () => {
-        const modesWithFlytogWithoutBus: SearchFilterType[] = ['flytog', 'metro', 'air', 'water']
-        const { filteredModes, subModesFilter } = filterModesAndSubModes(modesWithFlytogWithoutBus)
+        const modesWithFlytogWithoutBus: SearchFilterType[] = [
+            'flytog',
+            'metro',
+            'air',
+            'water',
+        ]
+        const { filteredModes, subModesFilter } = filterModesAndSubModes(
+            modesWithFlytogWithoutBus,
+        )
         const busFilter = getBusFilter(subModesFilter)
 
         expect(filteredModes).toContain(LegMode.BUS)
         expect(busFilter.transportMode).toEqual(LegMode.BUS)
-        expect(busFilter.transportSubmodes).toContain(TransportSubmode.RAIL_REPLACEMENT_BUS)
+        expect(busFilter.transportSubmodes).toContain(
+            TransportSubmode.RAIL_REPLACEMENT_BUS,
+        )
     })
 
     it('should include all sub modes except railReplacementBus if bus is present and both rail and flytog are missing', () => {
-        const modesWithoutRailWithBus: SearchFilterType[] = ['bus', 'flybuss', 'tram', 'metro', 'water']
-        const { subModesFilter } = filterModesAndSubModes(modesWithoutRailWithBus)
+        const modesWithoutRailWithBus: SearchFilterType[] = [
+            'bus',
+            'flybuss',
+            'tram',
+            'metro',
+            'water',
+        ]
+        const { subModesFilter } = filterModesAndSubModes(
+            modesWithoutRailWithBus,
+        )
         const busFilter = getBusFilter(subModesFilter)
 
-        expect(busFilter.transportSubmodes.length).toEqual(ALL_BUS_SUBMODES.filter(Boolean).length - 1)
-        expect(busFilter.transportSubmodes).not.toContain(TransportSubmode.RAIL_REPLACEMENT_BUS)
+        expect(busFilter.transportSubmodes.length).toEqual(
+            ALL_BUS_SUBMODES.filter(Boolean).length - 1,
+        )
+        expect(busFilter.transportSubmodes).not.toContain(
+            TransportSubmode.RAIL_REPLACEMENT_BUS,
+        )
     })
 
     it('should include rail mode and airportLinkRail sub mode if rail is missing and flytog is present', () => {
-        const modesWithoutRailWithFlytog: SearchFilterType[] = ['flytog', 'tram', 'metro', 'water']
-        const { filteredModes, subModesFilter } = filterModesAndSubModes(modesWithoutRailWithFlytog)
+        const modesWithoutRailWithFlytog: SearchFilterType[] = [
+            'flytog',
+            'tram',
+            'metro',
+            'water',
+        ]
+        const { filteredModes, subModesFilter } = filterModesAndSubModes(
+            modesWithoutRailWithFlytog,
+        )
         const railFilter = getRailFilter(subModesFilter)
 
         expect(filteredModes).toContain(LegMode.RAIL)
         expect(railFilter.transportMode).toEqual(LegMode.RAIL)
-        expect(railFilter.transportSubmodes).toContain(TransportSubmode.AIRPORT_LINK_RAIL)
+        expect(railFilter.transportSubmodes).toContain(
+            TransportSubmode.AIRPORT_LINK_RAIL,
+        )
     })
 
     it('should whitelist FLT if only foot and flytog are present', () => {
         const modesWithOnlyFootAndFlytog: any[] = ['flytog', 'foot']
-        const { banned, whiteListed } = filterModesAndSubModes(modesWithOnlyFootAndFlytog)
+        const { banned, whiteListed } = filterModesAndSubModes(
+            modesWithOnlyFootAndFlytog,
+        )
 
         expect(banned).toBeUndefined()
         expect(whiteListed).toEqual(flytogWhitelist)
     })
 
     it('should include all sub modes except airportLinkRail, and blacklist FLT, if rail is present and flytog is missing', () => {
-        const modesWithRailWithoutFlytog: SearchFilterType[] = ['rail', 'tram', 'metro', 'air']
-        const { subModesFilter, banned } = filterModesAndSubModes(modesWithRailWithoutFlytog)
+        const modesWithRailWithoutFlytog: SearchFilterType[] = [
+            'rail',
+            'tram',
+            'metro',
+            'air',
+        ]
+        const { subModesFilter, banned } = filterModesAndSubModes(
+            modesWithRailWithoutFlytog,
+        )
         const railFilter = getRailFilter(subModesFilter)
 
-        expect(railFilter.transportSubmodes.length).toEqual(ALL_RAIL_SUBMODES.length - 1)
-        expect(railFilter.transportSubmodes).not.toContain(TransportSubmode.AIRPORT_LINK_RAIL)
+        expect(railFilter.transportSubmodes.length).toEqual(
+            ALL_RAIL_SUBMODES.length - 1,
+        )
+        expect(railFilter.transportSubmodes).not.toContain(
+            TransportSubmode.AIRPORT_LINK_RAIL,
+        )
         expect(banned).toEqual(flytogWhitelist)
     })
 
     it('should not include any rail sub modes if both rail and flytog are present', () => {
-        const modesWithoutRailWithFlytog: SearchFilterType[] = ['rail', 'flytog', 'metro', 'water']
-        const { filteredModes, subModesFilter } = filterModesAndSubModes(modesWithoutRailWithFlytog)
+        const modesWithoutRailWithFlytog: SearchFilterType[] = [
+            'rail',
+            'flytog',
+            'metro',
+            'water',
+        ]
+        const { filteredModes, subModesFilter } = filterModesAndSubModes(
+            modesWithoutRailWithFlytog,
+        )
         const railFilter = getRailFilter(subModesFilter)
 
         expect(filteredModes).toContain(LegMode.RAIL)
@@ -105,21 +185,41 @@ describe('filterModesAndSubModes', () => {
     })
 
     it('should include bus mode and airportLinkBus sub mode if bus is missing and flybuss is present', () => {
-        const modesWithoutBusWithFlybuss: SearchFilterType[] = ['flybuss', 'tram', 'metro', 'water']
-        const { filteredModes, subModesFilter } = filterModesAndSubModes(modesWithoutBusWithFlybuss)
+        const modesWithoutBusWithFlybuss: SearchFilterType[] = [
+            'flybuss',
+            'tram',
+            'metro',
+            'water',
+        ]
+        const { filteredModes, subModesFilter } = filterModesAndSubModes(
+            modesWithoutBusWithFlybuss,
+        )
         const busFilter = getBusFilter(subModesFilter)
 
         expect(filteredModes).toContain(LegMode.BUS)
         expect(busFilter.transportMode).toEqual(LegMode.BUS)
-        expect(busFilter.transportSubmodes).toContain(TransportSubmode.AIRPORT_LINK_BUS)
+        expect(busFilter.transportSubmodes).toContain(
+            TransportSubmode.AIRPORT_LINK_BUS,
+        )
     })
 
     it('should include all sub modes except airportLinkBus if bus is present and flybuss is missing', () => {
-        const modesWithBusWithoutFlybuss: SearchFilterType[] = ['bus', 'tram', 'metro', 'air']
-        const { subModesFilter } = filterModesAndSubModes(modesWithBusWithoutFlybuss)
+        const modesWithBusWithoutFlybuss: SearchFilterType[] = [
+            'bus',
+            'tram',
+            'metro',
+            'air',
+        ]
+        const { subModesFilter } = filterModesAndSubModes(
+            modesWithBusWithoutFlybuss,
+        )
         const busFilter = getBusFilter(subModesFilter)
 
-        expect(busFilter.transportSubmodes.length).toEqual(ALL_BUS_SUBMODES.filter(Boolean).length - 1)
-        expect(busFilter.transportSubmodes).not.toContain(TransportSubmode.AIRPORT_LINK_BUS)
+        expect(busFilter.transportSubmodes.length).toEqual(
+            ALL_BUS_SUBMODES.filter(Boolean).length - 1,
+        )
+        expect(busFilter.transportSubmodes).not.toContain(
+            TransportSubmode.AIRPORT_LINK_BUS,
+        )
     })
 })

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -1,4 +1,6 @@
-export function clean<T>(obj: { [key: string]: T }): { [key: string]: Exclude<T, undefined> } {
+export function clean<T>(obj: {
+    [key: string]: T
+}): { [key: string]: Exclude<T, undefined> } {
     return Object.entries(obj).reduce((cleanObj, [key, value]) => {
         if (typeof value === 'undefined') {
             return cleanObj

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -20,9 +20,14 @@ interface Options {
 export function toISOString(date: Date, options: Options): string {
     if (!options.timeZone) return date.toISOString()
     const timeZone = findTimeZone(options.timeZone)
-    const { year, month, day, hours, minutes, seconds, zone } = getZonedTime(date, timeZone)
+    const { year, month, day, hours, minutes, seconds, zone } = getZonedTime(
+        date,
+        timeZone,
+    )
     const offset = zone?.offset
-    return `${year}-${pad(month)}-${pad(day)}T${pad(hours)}:${pad(minutes)}:${pad(seconds)}${formatOffset(offset)}`
+    return `${year}-${pad(month)}-${pad(day)}T${pad(hours)}:${pad(
+        minutes,
+    )}:${pad(seconds)}${formatOffset(offset)}`
 }
 
 // Lifted from date-fns-timezone

--- a/src/utils/tripPattern.test.ts
+++ b/src/utils/tripPattern.test.ts
@@ -4,7 +4,11 @@ import { Leg, LegMode, TripPattern } from '@entur/sdk'
 
 import { NON_TRANSIT_DISTANCE_LIMITS } from '../constants'
 
-import { isValidTaxiAlternative, isValidNonTransitDistance, hoursBetweenDateAndTripPattern } from './tripPattern'
+import {
+    isValidTaxiAlternative,
+    isValidNonTransitDistance,
+    hoursBetweenDateAndTripPattern,
+} from './tripPattern'
 
 const now = new Date()
 
@@ -24,10 +28,22 @@ describe('isValidTaxiAlternative', () => {
     const isValidTaxi = isValidTaxiAlternative(now, carPattern, false)
 
     it('should be false unless the given pattern has at least one CAR leg, and one non-CAR leg', () => {
-        const onlyMetro = mockPattern({ legs: [mockLeg({ mode: LegMode.METRO })] })
-        const metroTaxi = mockPattern({ legs: [mockLeg({ mode: LegMode.METRO }), mockLeg({ mode: LegMode.BUS })] })
+        const onlyMetro = mockPattern({
+            legs: [mockLeg({ mode: LegMode.METRO })],
+        })
+        const metroTaxi = mockPattern({
+            legs: [
+                mockLeg({ mode: LegMode.METRO }),
+                mockLeg({ mode: LegMode.BUS }),
+            ],
+        })
         const onlyTaxi = mockPattern({ legs: [mockLeg({ mode: LegMode.CAR })] })
-        const taxiTaxi = mockPattern({ legs: [mockLeg({ mode: LegMode.CAR }), mockLeg({ mode: LegMode.CAR })] })
+        const taxiTaxi = mockPattern({
+            legs: [
+                mockLeg({ mode: LegMode.CAR }),
+                mockLeg({ mode: LegMode.CAR }),
+            ],
+        })
 
         expect(isValidTaxi(onlyMetro)).toEqual(false)
         expect(isValidTaxi(metroTaxi)).toEqual(false)
@@ -56,10 +72,16 @@ describe('isValidTaxiAlternative', () => {
 
     it('should be false unless the taxi leg exceeds the min duration limit, but still shorter than the given car pattern', () => {
         const tooShortDuration = mockPattern({
-            legs: [mockLeg({ mode: LegMode.METRO }), mockLeg({ mode: LegMode.CAR })],
+            legs: [
+                mockLeg({ mode: LegMode.METRO }),
+                mockLeg({ mode: LegMode.CAR }),
+            ],
         })
         const tooLongDuration = mockPattern({
-            legs: [mockLeg({ mode: LegMode.METRO }), mockLeg({ mode: LegMode.CAR, duration: 1337 })],
+            legs: [
+                mockLeg({ mode: LegMode.METRO }),
+                mockLeg({ mode: LegMode.CAR, duration: 1337 }),
+            ],
         })
 
         expect(isValidTaxi(tooShortDuration)).toEqual(false)
@@ -67,50 +89,91 @@ describe('isValidTaxiAlternative', () => {
     })
 
     it('should be true only if the hours since search date is within the max limit for given timepicker mode', () => {
-        const isValidTaxiForArriveBy = isValidTaxiAlternative(now, carPattern, true)
-        const isValidTaxiForDepartAfter = isValidTaxiAlternative(now, carPattern, false)
+        const isValidTaxiForArriveBy = isValidTaxiAlternative(
+            now,
+            carPattern,
+            true,
+        )
+        const isValidTaxiForDepartAfter = isValidTaxiAlternative(
+            now,
+            carPattern,
+            false,
+        )
 
         const validArriveByAlternative = mockPattern({
             endTime: subHours(now, 3),
-            legs: [mockLeg({ mode: LegMode.METRO }), mockLeg({ mode: LegMode.CAR, duration: 420 })],
+            legs: [
+                mockLeg({ mode: LegMode.METRO }),
+                mockLeg({ mode: LegMode.CAR, duration: 420 }),
+            ],
         })
         const invalidArriveByAlternative = mockPattern({
             startTime: subHours(now, 4),
-            legs: [mockLeg({ mode: LegMode.METRO }), mockLeg({ mode: LegMode.CAR, duration: 420 })],
+            legs: [
+                mockLeg({ mode: LegMode.METRO }),
+                mockLeg({ mode: LegMode.CAR, duration: 420 }),
+            ],
         })
         const validDepartAfterAlternative = mockPattern({
             startTime: addHours(now, 3),
-            legs: [mockLeg({ mode: LegMode.METRO }), mockLeg({ mode: LegMode.CAR, duration: 420 })],
+            legs: [
+                mockLeg({ mode: LegMode.METRO }),
+                mockLeg({ mode: LegMode.CAR, duration: 420 }),
+            ],
         })
         const invalidDepartAfterAlternative = mockPattern({
             startTime: addHours(now, 4),
-            legs: [mockLeg({ mode: LegMode.METRO }), mockLeg({ mode: LegMode.CAR, duration: 420 })],
+            legs: [
+                mockLeg({ mode: LegMode.METRO }),
+                mockLeg({ mode: LegMode.CAR, duration: 420 }),
+            ],
         })
 
         expect(isValidTaxiForArriveBy(validArriveByAlternative)).toEqual(true)
-        expect(isValidTaxiForArriveBy(invalidArriveByAlternative)).toEqual(false)
-        expect(isValidTaxiForDepartAfter(validDepartAfterAlternative)).toEqual(true)
-        expect(isValidTaxiForDepartAfter(invalidDepartAfterAlternative)).toEqual(false)
+        expect(isValidTaxiForArriveBy(invalidArriveByAlternative)).toEqual(
+            false,
+        )
+        expect(isValidTaxiForDepartAfter(validDepartAfterAlternative)).toEqual(
+            true,
+        )
+        expect(
+            isValidTaxiForDepartAfter(invalidDepartAfterAlternative),
+        ).toEqual(false)
     })
 })
 
 describe('isValidNonTransitDistance', () => {
-    function mockPattern(mode: 'foot' | 'bicycle' | 'car', distanceDelta = 0): TripPattern {
+    function mockPattern(
+        mode: 'foot' | 'bicycle' | 'car',
+        distanceDelta = 0,
+    ): TripPattern {
         return {
             distance: NON_TRANSIT_DISTANCE_LIMITS.UPPER[mode] + distanceDelta,
         } as TripPattern
     }
 
     it('should be true if the given trip has a distance within the limits of the given mode', () => {
-        expect(isValidNonTransitDistance(mockPattern('car'), 'car')).toEqual(true)
-        expect(isValidNonTransitDistance(mockPattern('foot'), 'foot')).toEqual(true)
-        expect(isValidNonTransitDistance(mockPattern('bicycle'), 'bicycle')).toEqual(true)
+        expect(isValidNonTransitDistance(mockPattern('car'), 'car')).toEqual(
+            true,
+        )
+        expect(isValidNonTransitDistance(mockPattern('foot'), 'foot')).toEqual(
+            true,
+        )
+        expect(
+            isValidNonTransitDistance(mockPattern('bicycle'), 'bicycle'),
+        ).toEqual(true)
     })
 
     it('should be false if the given trip has a distance outside the limits of the given mode', () => {
-        expect(isValidNonTransitDistance(mockPattern('car', 1337), 'car')).toEqual(false)
-        expect(isValidNonTransitDistance(mockPattern('foot', 404), 'foot')).toEqual(false)
-        expect(isValidNonTransitDistance(mockPattern('bicycle', 42), 'bicycle')).toEqual(false)
+        expect(
+            isValidNonTransitDistance(mockPattern('car', 1337), 'car'),
+        ).toEqual(false)
+        expect(
+            isValidNonTransitDistance(mockPattern('foot', 404), 'foot'),
+        ).toEqual(false)
+        expect(
+            isValidNonTransitDistance(mockPattern('bicycle', 42), 'bicycle'),
+        ).toEqual(false)
     })
 })
 
@@ -120,18 +183,34 @@ describe('hoursBetweenDateAndTripPattern', () => {
     }
 
     it('should count the hours between the given date and the start of the trip if `arriveBy` is `false`', () => {
-        const startsInEightHours = mockPattern({ startTime: addHours(now, 8).toISOString() })
-        const startedTwoHoursAgo = mockPattern({ startTime: subHours(now, 2).toISOString() })
+        const startsInEightHours = mockPattern({
+            startTime: addHours(now, 8).toISOString(),
+        })
+        const startedTwoHoursAgo = mockPattern({
+            startTime: subHours(now, 2).toISOString(),
+        })
 
-        expect(hoursBetweenDateAndTripPattern(now, startsInEightHours, false)).toEqual(8)
-        expect(hoursBetweenDateAndTripPattern(now, startedTwoHoursAgo, false)).toEqual(2)
+        expect(
+            hoursBetweenDateAndTripPattern(now, startsInEightHours, false),
+        ).toEqual(8)
+        expect(
+            hoursBetweenDateAndTripPattern(now, startedTwoHoursAgo, false),
+        ).toEqual(2)
     })
 
     it('should count the hours between the given date and the end of the trip if `arriveBy` is `true`', () => {
-        const endsInElevenHours = mockPattern({ endTime: addHours(now, 11).toISOString() })
-        const endedFourHoursAgo = mockPattern({ endTime: subHours(now, 4).toISOString() })
+        const endsInElevenHours = mockPattern({
+            endTime: addHours(now, 11).toISOString(),
+        })
+        const endedFourHoursAgo = mockPattern({
+            endTime: subHours(now, 4).toISOString(),
+        })
 
-        expect(hoursBetweenDateAndTripPattern(now, endsInElevenHours, true)).toEqual(11)
-        expect(hoursBetweenDateAndTripPattern(now, endedFourHoursAgo, true)).toEqual(4)
+        expect(
+            hoursBetweenDateAndTripPattern(now, endsInElevenHours, true),
+        ).toEqual(11)
+        expect(
+            hoursBetweenDateAndTripPattern(now, endedFourHoursAgo, true),
+        ).toEqual(4)
     })
 })

--- a/src/utils/tripPattern.ts
+++ b/src/utils/tripPattern.ts
@@ -19,7 +19,9 @@ export function isFlexibleAlternative({ legs }: TripPattern): boolean {
 }
 
 export function isValidTransitAlternative(pattern: TripPattern): boolean {
-    return isTransitAlternative(pattern) && isFlexibleTripsInCombination(pattern)
+    return (
+        isTransitAlternative(pattern) && isFlexibleTripsInCombination(pattern)
+    )
 }
 
 export function isValidTaxiAlternative(
@@ -31,7 +33,8 @@ export function isValidTaxiAlternative(
         isTaxiAlternative(taxiPattern) &&
         isFlexibleTripsInCombination(taxiPattern) &&
         isTaxiAlternativeBetterThanCarAlternative(taxiPattern, carPattern) &&
-        hoursBetweenDateAndTripPattern(searchDate, taxiPattern, arriveBy) < TAXI_LIMITS.DURATION_MAX_HOURS
+        hoursBetweenDateAndTripPattern(searchDate, taxiPattern, arriveBy) <
+            TAXI_LIMITS.DURATION_MAX_HOURS
 }
 
 export function isValidNonTransitDistance(
@@ -62,17 +65,28 @@ export function parseTripPattern(rawTripPattern: any): TripPattern {
         ...rawTripPattern,
         id: rawTripPattern.id || uuid(),
         legs: rawTripPattern.legs.map(parseLeg),
-        genId: `${new Date().getTime()}:${Math.random().toString(36).slice(2, 12)}`,
+        genId: `${new Date().getTime()}:${Math.random()
+            .toString(36)
+            .slice(2, 12)}`,
     }
 }
 
-export function hoursBetweenDateAndTripPattern(date: Date, tripPattern: TripPattern, arriveBy: boolean): number {
-    const tripPatternDate = parseISO(arriveBy ? tripPattern.endTime : tripPattern.startTime)
+export function hoursBetweenDateAndTripPattern(
+    date: Date,
+    tripPattern: TripPattern,
+    arriveBy: boolean,
+): number {
+    const tripPatternDate = parseISO(
+        arriveBy ? tripPattern.endTime : tripPattern.startTime,
+    )
 
     return Math.abs(differenceInHours(tripPatternDate, date))
 }
 
-function isTaxiAlternativeBetterThanCarAlternative({ legs }: TripPattern, carPattern?: TripPattern): boolean {
+function isTaxiAlternativeBetterThanCarAlternative(
+    { legs }: TripPattern,
+    carPattern?: TripPattern,
+): boolean {
     const taxiLeg = legs.find(({ mode }) => mode === LegMode.CAR)
 
     if (!taxiLeg || typeof taxiLeg.duration !== 'number') return true
@@ -80,7 +94,8 @@ function isTaxiAlternativeBetterThanCarAlternative({ legs }: TripPattern, carPat
     const taxiDuration = taxiLeg.duration || 0
 
     return (
-        taxiDuration > TAXI_LIMITS.DURATION_MIN_SECONDS && (!carPattern?.duration || taxiDuration < carPattern.duration)
+        taxiDuration > TAXI_LIMITS.DURATION_MIN_SECONDS &&
+        (!carPattern?.duration || taxiDuration < carPattern.duration)
     )
 }
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -59,4 +59,12 @@ export interface FilteredModesAndSubModes {
     whiteListed?: InputWhiteListed
 }
 
-export type SearchFilterType = 'bus' | 'rail' | 'tram' | 'metro' | 'air' | 'water' | 'flytog' | 'flybuss'
+export type SearchFilterType =
+    | 'bus'
+    | 'rail'
+    | 'tram'
+    | 'metro'
+    | 'air'
+    | 'water'
+    | 'flytog'
+    | 'flybuss'


### PR DESCRIPTION
Dagens 120 tegn per linje er for langt for splitta diff på laptop.. så kvifor ikkje bruke Prettier sin anbefalte default på 80 teikn?

>>>
    For readability we recommend against using more than 80 characters:

    In code styleguides, maximum line length rules are often set to 100 or 120. However, when humans write code, they don't strive to reach the maximum number of columns on every line. Developers often use whitespace to break up long lines for readability. In practice, the average line length often ends up well below the maximum.

    Prettier, on the other hand, strives to fit the most code into every line. With the print width set to 120, prettier may produce overly compact, or otherwise undesirable code.

    See the print width rationale for more information.

https://prettier.io/docs/en/options.html