### PR TITLE
Fix bug in parsing startTime/endTime

### DIFF
--- a/src/utils/tripPattern.ts
+++ b/src/utils/tripPattern.ts
@@ -1,6 +1,6 @@
 import { isCar, LegMode, TripPattern } from '@entur/sdk'
 import { v4 as uuid } from 'uuid'
-import { differenceInHours, parseJSON } from 'date-fns'
+import { differenceInHours, parseISO } from 'date-fns'
 
 import { NON_TRANSIT_DISTANCE_LIMITS, TAXI_LIMITS } from '../constants'
 
@@ -67,7 +67,7 @@ export function parseTripPattern(rawTripPattern: any): TripPattern {
 }
 
 export function hoursBetweenDateAndTripPattern(date: Date, tripPattern: TripPattern, arriveBy: boolean): number {
-    const tripPatternDate = parseJSON(arriveBy ? tripPattern.endTime : tripPattern.startTime)
+    const tripPatternDate = parseISO(arriveBy ? tripPattern.endTime : tripPattern.startTime)
 
     return Math.abs(differenceInHours(tripPatternDate, date))
 }


### PR DESCRIPTION
The timestamps on trip patterns are missing a colon in the timezone offset. parseISO handles this correctly, parseJSON doesn't.

<img width="401" alt="image" src="https://user-images.githubusercontent.com/4339443/83644700-d9cb5f80-a5b1-11ea-96eb-faffb2c3ff6c.png">
<img width="364" alt="image" src="https://user-images.githubusercontent.com/4339443/83644756-e780e500-a5b1-11ea-922e-72424fc92305.png">
