### PR TITLE
Setup CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,8 @@
+version: 2.1
+orbs:
+    node: 'circleci/node@3.0.1'
+workflows:
+    build-and-test:
+        jobs:
+            - node/test:
+                version: 10.22.0


### PR DESCRIPTION
Bruker CircleCI sin Node orb for å forenkle oppsettet: https://circleci.com/orbs/registry/orb/circleci/node#executors-default

Den køyrer i praksis `npm test` på Node v10.22.0.