### PR TITLE
Fix trip updates for self driving bus in Ålgård

### DIFF
--- a/src/otp1/updateTrip.ts
+++ b/src/otp1/updateTrip.ts
@@ -167,11 +167,13 @@ async function updateLeg(leg: Leg): Promise<LegWithUpdate> {
 
     const toFrontText = toEstimatedCall.destinationDisplay?.frontText
     const toQuayId = toEstimatedCall.quay?.id || ''
-    const toIndex = findCallIndexByQuayId(
-        updatedEstimatedCalls,
-        toQuayId,
-        toFrontText,
-    )
+
+    const remainingUpdatedCalls = updatedEstimatedCalls.slice(fromIndex + 1)
+
+    const toIndex =
+        findCallIndexByQuayId(remainingUpdatedCalls, toQuayId, toFrontText) +
+        fromIndex +
+        1
     const toCall = updatedEstimatedCalls[toIndex]
     if (!toCall) return { leg }
 

--- a/src/otp1/updateTrip.ts
+++ b/src/otp1/updateTrip.ts
@@ -252,7 +252,7 @@ function updateNonTransitLeg(
         if (!updatedCalls) return leg
 
         const { toCall } = updatedCalls
-        const { expectedDepartureTime: expectedStartTime, quay } = toCall
+        const { expectedArrivalTime: expectedStartTime, quay } = toCall
         const { timezone: timeZone } = quay
 
         const expectedEndTime = toISOString(
@@ -267,7 +267,7 @@ function updateNonTransitLeg(
         if (!updatedCalls) return leg
 
         const { fromCall } = updatedCalls
-        const { expectedArrivalTime: expectedEndTime, quay } = fromCall
+        const { expectedDepartureTime: expectedEndTime, quay } = fromCall
         const { timezone: timeZone } = quay
 
         const expectedStartTime = toISOString(


### PR DESCRIPTION
Nokre service journeys går i ring, altså at siste estimated call går frå samme quay som første (A -> B -> C -> A). Vår logikk for å finne oppdatert estimated call for ein viss quay (`toIndex`/`toCall`) har ikkje tatt hensyn til dette. Derfor har den første estimatedCallen blitt brukt, og me har fått reiser som går "tilbake i tid". 
Eg har fiksa dette ved å slice `updatedEstimatedCalls` slik at `toCall` alltid vil vere etter `fromCall` i tid.

I tillegg vart det feil oppdatert tid på non-transit legs dersom første eller siste transit-leg hadde ventetid på stoppet. `expectedArrivalTime` og `expectedDepartureTime` var bytta om. expectedDepartureTime er når bussen drar frå stoppet, `expectedArrivalTime` er når bussen ankommer samme stoppet. Så `expectedArrivalTime` skal alltid vere før  `expectedDepartureTime`, og som oftast er `expectedDepartureTime == expectedArrivalTime`

 