### PR TITLE
Remove numTripPatterns and fix transferSlack for OTP2

### DIFF
--- a/src/otp2/controller.ts
+++ b/src/otp2/controller.ts
@@ -107,7 +107,6 @@ function getTripPatternsVariables(params: any): any {
         modes = DEFAULT_MODES,
         transportSubmodes = [],
         wheelchairAccessible = false,
-        limit = 5,
         ...rest
     } = params || {}
 
@@ -120,7 +119,6 @@ function getTripPatternsVariables(params: any): any {
         modes,
         transportSubmodes,
         wheelchair: wheelchairAccessible,
-        numTripPatterns: limit,
     }
 }
 

--- a/src/otp2/query.ts
+++ b/src/otp2/query.ts
@@ -1,6 +1,6 @@
 export default `
 query (
-    $numTripPatterns: Int!,
+    $numTripPatterns: Int,
     $from: Location!,
     $to: Location!,
     $dateTime: DateTime!,
@@ -28,7 +28,7 @@ query (
             transportSubmodes: $transportSubmodes,
             maxPreTransitWalkDistance: $maxPreTransitWalkDistance,
             walkSpeed: $walkSpeed,
-            minimumTransferTime: $minimumTransferTime,
+            transferSlack: $minimumTransferTime,
             allowBikeRental: $allowBikeRental,
             useFlex: $useFlex,
             banned: $banned,


### PR DESCRIPTION
I OTP2 er `minimumTransferTime` bytta ut med `transferSlack`.

Begrensning på antall trip patterns er fjerna då dette kan redusere kvalitet på reiseforslaga.