### PR TITLE
Support OTP2 submodes and new Modes format

### DIFF
--- a/src/otp2/index.ts
+++ b/src/otp2/index.ts
@@ -5,13 +5,12 @@ import { TripPattern } from '@entur/sdk'
 
 import { set as cacheSet, get as cacheGet } from '../cache'
 import { NotFoundError } from '../errors'
-import { RawSearchParams, SearchParams, GraphqlQuery } from '../../types'
+import { RawSearchParams, GraphqlQuery, SearchParams } from '../../types'
 
 import { searchTransit, searchNonTransit, NonTransitMode } from './controller'
 import { updateTripPattern, getExpires } from './updateTrip'
 
 import { parseCursor, generateCursor } from './cursor'
-import { filterModesAndSubModes } from '../utils/modes'
 import { buildShamashLink } from '../utils/graphql'
 import { clean } from '../utils/object'
 
@@ -49,21 +48,11 @@ function getParams(params: RawSearchParams): SearchParams {
     const searchDate = params.searchDate
         ? parseJSON(params.searchDate)
         : new Date()
-    const {
-        filteredModes,
-        subModesFilter,
-        banned,
-        whiteListed,
-    } = filterModesAndSubModes(params.searchFilter)
 
     return {
         ...params,
         searchDate,
         initialSearchDate: searchDate,
-        modes: filteredModes,
-        transportSubmodes: subModesFilter,
-        banned,
-        whiteListed,
     }
 }
 

--- a/src/otp2/modes.test.ts
+++ b/src/otp2/modes.test.ts
@@ -1,0 +1,201 @@
+import { LegMode, TransportSubmode } from '@entur/sdk'
+
+import { filterModesAndSubModes, Modes, Mode } from './modes'
+
+import { SearchFilterType } from '../../types'
+
+import { ALL_BUS_SUBMODES, ALL_RAIL_SUBMODES } from '../constants'
+
+function getBusFilter(modes: Modes): Mode | undefined {
+    return modes.transportModes.find(
+        (mode) => mode.transportMode === LegMode.BUS,
+    )
+}
+
+function getRailFilter(modes: Modes): Mode | undefined {
+    return modes.transportModes.find(
+        (mode) => mode.transportMode === LegMode.RAIL,
+    )
+}
+
+describe('filterModesAndSubModes', () => {
+    it('should include coach mode if bus mode is present', () => {
+        const modesWithBusWithoutCoach: SearchFilterType[] = [
+            'rail',
+            'metro',
+            'bus',
+            'water',
+        ]
+        const modesWithBusAndCoach: any = ['bus', 'coach']
+        const withoutCoach = filterModesAndSubModes(modesWithBusWithoutCoach)
+        const withCoach = filterModesAndSubModes(modesWithBusAndCoach)
+
+        const coach = withoutCoach.transportModes.some(
+            (m) => m.transportMode === LegMode.COACH,
+        )
+        expect(coach).toEqual(true)
+
+        const alreadyCoach = withCoach.transportModes.some(
+            (m) => m.transportMode === LegMode.COACH,
+        )
+        expect(alreadyCoach).toEqual(true)
+        expect(withCoach.transportModes).toHaveLength(
+            modesWithBusAndCoach.length,
+        )
+    })
+
+    it('should include bus mode and railReplacementBus sub mode if rail mode is present', () => {
+        const modesWithRailWithoutBus: SearchFilterType[] = [
+            'rail',
+            'metro',
+            'air',
+            'water',
+        ]
+        const filteredModes = filterModesAndSubModes(modesWithRailWithoutBus)
+        const busMode = getBusFilter(filteredModes)
+
+        expect(busMode).toBeTruthy()
+        expect(busMode?.transportSubModes).toContain(
+            TransportSubmode.RAIL_REPLACEMENT_BUS,
+        )
+    })
+
+    it('should include bus mode and railReplacementBus sub mode if flytog mode is present', () => {
+        const modesWithFlytogWithoutBus: SearchFilterType[] = [
+            'flytog',
+            'metro',
+            'air',
+            'water',
+        ]
+        const filteredModes = filterModesAndSubModes(modesWithFlytogWithoutBus)
+        const busMode = getBusFilter(filteredModes)
+
+        expect(busMode).toBeTruthy()
+        expect(busMode?.transportSubModes).toContain(
+            TransportSubmode.RAIL_REPLACEMENT_BUS,
+        )
+    })
+
+    it('should include all sub modes except railReplacementBus if bus is present and both rail and flytog are missing', () => {
+        const modesWithoutRailWithBus: SearchFilterType[] = [
+            'bus',
+            'flybuss',
+            'tram',
+            'metro',
+            'water',
+        ]
+        const modes = filterModesAndSubModes(modesWithoutRailWithBus)
+        const busMode = getBusFilter(modes)
+
+        expect(busMode?.transportSubModes).toHaveLength(
+            ALL_BUS_SUBMODES.length - 1,
+        )
+        expect(busMode?.transportSubModes).not.toContain(
+            TransportSubmode.RAIL_REPLACEMENT_BUS,
+        )
+    })
+
+    it('should include all sub modes except railReplacementBus and airportLinkBus if bus is present and both rail, flytog and flybuss are missing', () => {
+        const modesWithoutRailWithBus: SearchFilterType[] = [
+            'bus',
+            'tram',
+            'metro',
+            'water',
+        ]
+        const modes = filterModesAndSubModes(modesWithoutRailWithBus)
+        const busMode = getBusFilter(modes)
+
+        expect(busMode?.transportSubModes).toHaveLength(
+            ALL_BUS_SUBMODES.length - 2,
+        )
+        expect(busMode?.transportSubModes).not.toContain(
+            TransportSubmode.RAIL_REPLACEMENT_BUS,
+        )
+        expect(busMode?.transportSubModes).not.toContain(
+            TransportSubmode.AIRPORT_LINK_BUS,
+        )
+    })
+
+    it('should include rail mode and airportLinkRail sub mode if rail is missing and flytog is present', () => {
+        const modesWithoutRailWithFlytog: SearchFilterType[] = [
+            'flytog',
+            'tram',
+            'metro',
+            'water',
+        ]
+        const filteredModes = filterModesAndSubModes(modesWithoutRailWithFlytog)
+        const railFilter = getRailFilter(filteredModes)
+
+        expect(railFilter).toBeTruthy()
+        expect(railFilter?.transportSubModes).toContain(
+            TransportSubmode.AIRPORT_LINK_RAIL,
+        )
+    })
+
+    it('should include all sub modes except airportLinkRail if rail is present and flytog is missing', () => {
+        const modesWithRailWithoutFlytog: SearchFilterType[] = [
+            'rail',
+            'tram',
+            'metro',
+            'air',
+        ]
+        const modes = filterModesAndSubModes(modesWithRailWithoutFlytog)
+        const railFilter = getRailFilter(modes)
+
+        expect(railFilter?.transportSubModes).toHaveLength(
+            ALL_RAIL_SUBMODES.length - 1,
+        )
+        expect(railFilter?.transportSubModes).not.toContain(
+            TransportSubmode.AIRPORT_LINK_RAIL,
+        )
+    })
+
+    it('should not include any rail sub modes if both rail and flytog are present', () => {
+        const modesWithoutRailWithFlytog: SearchFilterType[] = [
+            'rail',
+            'flytog',
+            'metro',
+            'water',
+        ]
+        const filteredModes = filterModesAndSubModes(modesWithoutRailWithFlytog)
+        const railFilter = getRailFilter(filteredModes)
+        expect(railFilter).toBeTruthy()
+        expect(railFilter?.transportSubModes).toBeUndefined()
+    })
+
+    it('should include bus mode and airportLinkBus sub mode if bus is missing and flybuss is present', () => {
+        const modesWithoutBusWithFlybuss: SearchFilterType[] = [
+            'flybuss',
+            'tram',
+            'metro',
+            'water',
+        ]
+        const modes = filterModesAndSubModes(modesWithoutBusWithFlybuss)
+        const busMode = getBusFilter(modes)
+        expect(busMode).toBeTruthy()
+        expect(busMode?.transportSubModes).toBeTruthy()
+        expect(busMode?.transportSubModes).toHaveLength(1)
+        expect(busMode?.transportSubModes).toContain(
+            TransportSubmode.AIRPORT_LINK_BUS,
+        )
+    })
+
+    it('should include all sub modes except airportLinkBus if bus is present and flybuss is missing', () => {
+        const modesWithBusWithoutFlybuss: SearchFilterType[] = [
+            'bus',
+            'rail',
+            'tram',
+            'metro',
+            'air',
+        ]
+        const modes = filterModesAndSubModes(modesWithBusWithoutFlybuss)
+        const busMode = getBusFilter(modes)
+
+        expect(busMode?.transportSubModes).toHaveLength(
+            ALL_BUS_SUBMODES.length - 1,
+        )
+        expect(busMode?.transportSubModes).not.toContain(
+            TransportSubmode.AIRPORT_LINK_BUS,
+        )
+    })
+})

--- a/src/otp2/modes.ts
+++ b/src/otp2/modes.ts
@@ -1,0 +1,221 @@
+import { TransportMode, TransportSubmode, LegMode } from '@entur/sdk'
+import { uniq } from '../utils/array'
+import { SearchFilterType } from '../../types'
+import { ALL_BUS_SUBMODES, ALL_RAIL_SUBMODES } from '../constants'
+
+export type StreetMode =
+    | 'foot'
+    | 'bicycle'
+    | 'bike_park'
+    | 'bike_rental'
+    | 'car'
+    | 'car_park'
+    | 'taxi'
+    | 'car_rental'
+
+export interface Mode {
+    transportMode: TransportMode
+    transportSubModes?: TransportSubmode[]
+}
+
+export interface Modes {
+    accessMode: StreetMode
+    egressMode: StreetMode
+    directMode?: StreetMode
+    transportModes: Mode[]
+}
+
+export const DEFAULT_MODES: Modes = {
+    accessMode: 'foot',
+    egressMode: 'foot',
+    transportModes: [
+        { transportMode: 'bus' },
+        { transportMode: 'tram' },
+        { transportMode: 'rail' },
+        { transportMode: 'metro' },
+        { transportMode: 'water' },
+        { transportMode: 'air' },
+    ],
+}
+
+const flybuss = 'flybuss'
+const flytog = 'flytog'
+
+export function isTransportMode(mode: string): mode is TransportMode {
+    return (
+        mode === 'air' ||
+        mode === 'bus' ||
+        mode === 'cableway' ||
+        mode === 'water' ||
+        mode === 'funicular' ||
+        mode === 'lift' ||
+        mode === 'rail' ||
+        mode === 'metro' ||
+        mode === 'tram' ||
+        mode === 'coach' ||
+        mode === 'unknown'
+    )
+}
+
+function queryTransportModesReducer(
+    transportModes: TransportMode[],
+    mode: SearchFilterType,
+): TransportMode[] {
+    return isTransportMode(mode)
+        ? [...transportModes, mode as TransportMode]
+        : transportModes
+}
+
+function convertSearchFiltersToMode(
+    searchFilters: SearchFilterType[],
+): TransportMode[] {
+    const initialModes: TransportMode[] = searchFilters.includes('bus')
+        ? ['coach']
+        : []
+
+    return uniq(searchFilters.reduce(queryTransportModesReducer, initialModes))
+}
+
+function filterModesForRailReplacementBus(
+    filters: SearchFilterType[],
+): Mode | undefined {
+    const replacementBus = TransportSubmode.RAIL_REPLACEMENT_BUS
+    const filtersIncludeRailOrFlytog = [LegMode.RAIL, flytog].some((filter) =>
+        filters.includes(filter as SearchFilterType),
+    )
+
+    if (filtersIncludeRailOrFlytog && !filters.includes(LegMode.BUS)) {
+        return {
+            transportMode: LegMode.BUS,
+            transportSubModes: [replacementBus],
+        }
+    }
+
+    if (filters.includes(LegMode.BUS) && !filtersIncludeRailOrFlytog) {
+        const allOtherBusSubModes = ALL_BUS_SUBMODES.filter(
+            (filter: TransportSubmode) => filter !== replacementBus,
+        )
+
+        return {
+            transportMode: LegMode.BUS,
+            transportSubModes: allOtherBusSubModes,
+        }
+    }
+}
+
+function filterModesForAirportLinkRail(
+    filters: SearchFilterType[],
+): Mode | undefined {
+    const airportRail = TransportSubmode.AIRPORT_LINK_RAIL
+
+    if (filters.includes(flytog) && !filters.includes(LegMode.RAIL)) {
+        return {
+            transportMode: LegMode.RAIL,
+            transportSubModes: [airportRail],
+        }
+    }
+
+    if (filters.includes(LegMode.RAIL) && !filters.includes(flytog)) {
+        const allOtherRailSubModes: TransportSubmode[] = ALL_RAIL_SUBMODES.filter(
+            (mode: TransportSubmode) => mode !== airportRail,
+        )
+
+        return {
+            transportMode: LegMode.RAIL,
+            transportSubModes: allOtherRailSubModes,
+        }
+    }
+
+    return undefined
+}
+
+function filterModesForAirportLinkBus(
+    filters: SearchFilterType[],
+    previousBusSubModes: TransportSubmode[],
+): Mode | undefined {
+    if (filters.includes(flybuss) && !filters.includes(LegMode.BUS)) {
+        return {
+            transportMode: LegMode.BUS,
+            transportSubModes: [
+                ...previousBusSubModes,
+                TransportSubmode.AIRPORT_LINK_BUS,
+            ],
+        }
+    }
+
+    if (filters.includes(LegMode.BUS) && !filters.includes(flybuss)) {
+        const filtersIncludeRailOrFlytog = [
+            LegMode.RAIL,
+            flytog,
+        ].some((filter) => filters.includes(filter as SearchFilterType))
+
+        const allOtherBusSubModes = ALL_BUS_SUBMODES.filter(
+            (mode) =>
+                mode !== TransportSubmode.AIRPORT_LINK_BUS &&
+                (filtersIncludeRailOrFlytog ||
+                    mode !== TransportSubmode.RAIL_REPLACEMENT_BUS),
+        )
+
+        return {
+            transportMode: LegMode.BUS,
+            transportSubModes: allOtherBusSubModes,
+        }
+    }
+}
+
+function isSameMode(a: Mode, b: Mode): boolean {
+    return a.transportMode === b.transportMode
+}
+
+function updateMode(modes: Mode[], mode: Mode): Mode[] {
+    if (!modes.some((m) => isSameMode(m, mode))) {
+        return [...modes, mode]
+    }
+    return modes.map((m) => (isSameMode(m, mode) ? mode : m))
+}
+
+export function filterModesAndSubModes(filters?: SearchFilterType[]): Modes {
+    if (!filters) {
+        return DEFAULT_MODES
+    }
+
+    let filteredModes: Mode[] = convertSearchFiltersToMode(
+        filters,
+    ).map((transportMode) => ({ transportMode }))
+
+    /*
+     * Handle the 'railReplacementBus' sub mode as either a rail-related sub mode
+     * or flytog-related sub mode, instead of a bus-related sub mode.
+     */
+    const modeForReplacementBus = filterModesForRailReplacementBus(filters)
+    if (modeForReplacementBus) {
+        filteredModes = updateMode(filteredModes, modeForReplacementBus)
+    }
+
+    /*
+     * Handle the 'flytog' mode as the 'airportLinkRail' sub mode.
+     * Black-/Whitelist 'flytog' depending on 'rail' filter for more finely tuned results.
+     */
+    const modeForAirportLinkRail = filterModesForAirportLinkRail(filters)
+    if (modeForAirportLinkRail) {
+        filteredModes = updateMode(filteredModes, modeForAirportLinkRail)
+    }
+
+    /*
+     * Handle the 'flybuss' mode as the 'airportLinkBus' sub mode.
+     * Merge bus-related sub modes with existing bus-related sub modes.
+     */
+    const busMode = filteredModes.find((m) => m.transportMode === LegMode.BUS)
+    const modeForAirportLinkBus = filterModesForAirportLinkBus(
+        filters,
+        busMode?.transportSubModes || [],
+    )
+    if (modeForAirportLinkBus) {
+        filteredModes = updateMode(filteredModes, modeForAirportLinkBus)
+    }
+
+    return {
+        ...DEFAULT_MODES,
+        transportModes: filteredModes,
+    }
+}

--- a/src/otp2/query.ts
+++ b/src/otp2/query.ts
@@ -235,7 +235,6 @@ fragment serviceJourneyFields on ServiceJourney {
     }
     publicCode
     privateCode
-    transportSubmode
 }
 
 fragment interchangeFields on Interchange {


### PR DESCRIPTION
OTP2 kjem med støtte for submodes no, og sammen med det har `modes`-parameteret fått eit nytt, breaking format. Så eg har tilpassa våre funksjonar for å generere modes-parameter frå søkefilter.