### PR TITLE
Implement OTP 2 switch for scenario 3 for non-prod

### DIFF
--- a/src/otp1/index.ts
+++ b/src/otp1/index.ts
@@ -115,7 +115,6 @@ function searchQualifiesForScenario2(params: SearchParams): boolean {
 
 /*
  * OTP 2 scenario 3:
- * Scenario 2 or
  * From and to are north of latitude 67.5
  * Air filter disabled
  */
@@ -123,21 +122,21 @@ function searchQualifiesForScenario3(params: SearchParams): boolean {
     const { from, to } = params
     if (!from.coordinates || !to.coordinates) return false
 
-    if (
+    return (
         from.coordinates.latitude > 67.5 &&
         to.coordinates.latitude > 67.5 &&
         !params.searchFilter?.includes(SearchFilter.AIR)
-    ) {
-        return true
-    }
-
-    return searchQualifiesForScenario2(params)
+    )
 }
 
 function shouldUseOtp2(params: SearchParams): boolean {
-    return ENVIRONMENT === 'prod'
-        ? searchQualifiesForScenario2(params)
-        : searchQualifiesForScenario3(params)
+    if (ENVIRONMENT === 'prod') {
+        searchQualifiesForScenario2(params)
+    }
+    return (
+        searchQualifiesForScenario3(params) ||
+        searchQualifiesForScenario2(params)
+    )
 }
 
 router.post('/v1/transit', async (req, res, next) => {


### PR DESCRIPTION
Neste scenario for gradvis prodsetting av OTP 2. Denne gangen tillét me togfilter på, og har ingen minimumsdistanse, men kun for søk nord for Fauske (så ingen togreiser er mulig uansett). 