### PR TITLE
Continue OTP2 searches solely based on metadata

### DIFF
--- a/src/otp1/index.ts
+++ b/src/otp1/index.ts
@@ -186,7 +186,7 @@ router.post('/v1/transit', async (req, res, next) => {
 
         stopTrace = trace('generateCursor')
         const nextCursor = useOtp2
-            ? generateCursorOtp2(params, metadata, tripPatterns)
+            ? generateCursorOtp2(params, metadata)
             : generateCursor(params, tripPatterns)
         stopTrace()
 

--- a/src/otp2/cursor.ts
+++ b/src/otp2/cursor.ts
@@ -4,13 +4,6 @@ import {
 } from 'lz-string'
 import { parseJSON } from 'date-fns'
 
-import { TripPattern } from '@entur/sdk'
-
-import {
-    isTransitAlternative,
-    isFlexibleAlternative,
-} from '../utils/tripPattern'
-
 import { CursorData, SearchParams, Metadata } from '../types'
 
 export function parseCursor(cursor?: string): CursorData | undefined {
@@ -35,12 +28,8 @@ export function parseCursor(cursor?: string): CursorData | undefined {
 export function generateCursor(
     params: SearchParams,
     metadata: Metadata | undefined,
-    tripPatterns: TripPattern[] = [],
 ): string | undefined {
-    const hasTransitPatterns = tripPatterns.some(isTransitAlternative)
-    const hasFlexiblePatterns = tripPatterns.some(isFlexibleAlternative)
-
-    if (!metadata || !tripPatterns.length || !hasTransitPatterns) return
+    if (!metadata) return
 
     const nextDate = new Date(metadata.nextDateTime)
 
@@ -49,7 +38,7 @@ export function generateCursor(
         params: {
             ...params,
             searchDate: nextDate,
-            useFlex: hasFlexiblePatterns,
+            useFlex: false,
         },
     }
 

--- a/src/otp2/index.ts
+++ b/src/otp2/index.ts
@@ -79,7 +79,7 @@ router.post('/v1/transit', async (req, res, next) => {
                       shamash: generateShamashLink(query),
                   }))
 
-        const nextCursor = generateCursor(params, metadata, tripPatterns)
+        const nextCursor = generateCursor(params, metadata)
 
         Promise.all(
             tripPatterns.map((tripPattern) =>


### PR DESCRIPTION
Me bør returnere cursors til klienten dersom OTP 2 returnerer `metadata.nextDateTime` – uansett om det nylig kjørte søket returnerte tripPatterns eller ikkje.

Dette fikser at nokon søk blir avslutta litt for tidlig.