### PR TITLE
Enforce handling of 'floating' promises

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,7 @@ module.exports = {
     parserOptions: {
         ecmaVersion: 6,
         sourceType: 'module',
+        project: './tsconfig.eslint.json',
     },
     plugins: ['@typescript-eslint', 'fp', 'prettier'],
     settings: {
@@ -38,6 +39,7 @@ module.exports = {
         '@typescript-eslint/no-empty-function': 'error',
         '@typescript-eslint/no-empty-interface': 'error',
         '@typescript-eslint/no-explicit-any': 'off',
+        '@typescript-eslint/no-floating-promises': 'error',
         '@typescript-eslint/no-misused-new': 'error',
         '@typescript-eslint/no-namespace': 'error',
         '@typescript-eslint/no-parameter-properties': 'off',

--- a/scripts/environment.ts
+++ b/scripts/environment.ts
@@ -9,16 +9,18 @@ const mkdir = promisify(fs.mkdir)
 const [, , ENV = 'dev', ...args] = process.argv
 const ENV_FILE = join(__dirname, `../.env.${ENV}`)
 
-createConfigFile()
+void createConfigFile()
 
 if (args.includes('--with-types')) {
-    createTypeDefinition()
+    createTypeDefinition().catch((error) => {
+        console.error('Failed creating type definition', error)
+    })
 }
 
 if (args.includes('--watch')) {
     // eslint-disable-next-line fp/no-mutating-methods
     fs.watch(ENV_FILE, () => {
-        createConfigFile()
+        void createConfigFile()
     })
 }
 

--- a/src/otp1/index.ts
+++ b/src/otp1/index.ts
@@ -179,9 +179,15 @@ router.post('/v1/transit', async (req, res, next) => {
 
         if (!cursorData) {
             const stopLogTransitAnalyticsTrace = trace('logTransitAnalytics')
-            logTransitAnalytics(params, extraHeaders).then(
-                stopLogTransitAnalyticsTrace,
-            )
+            logTransitAnalytics(params, extraHeaders)
+                .then(stopLogTransitAnalyticsTrace)
+                .catch((error) => {
+                    logger.error('Failed to log transit analytics', {
+                        error: error.message,
+                        stack: error.stack,
+                        correlationId,
+                    })
+                })
         }
 
         stopTrace = trace('generateCursor')

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,7 +6,7 @@ import cors from 'cors'
 import express from 'express'
 
 import './cache'
-import { reqResLoggerMiddleware } from './logger'
+import logger, { reqResLoggerMiddleware } from './logger'
 import { NotFoundError, InvalidArgumentError } from './errors'
 import { unauthorizedError } from './auth'
 
@@ -29,7 +29,9 @@ if (process.env.NODE_ENV === 'production') {
 app.use(cors())
 
 app.get('/_ah/warmup', (_req, res) => {
-    import('./cache')
+    import('./cache').catch((error) =>
+        logger.error('Failed to import cache in warmup handler', error),
+    )
     res.end()
 })
 

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,11 @@
+{
+    "compilerOptions": {
+        "strict": true
+    },
+    "include": [
+        ".eslintrc.js",
+        "./*.js",
+        "./src/**/*.ts",
+        "./scripts/**/*.ts",
+    ]
+  }


### PR DESCRIPTION
This ESLint rule forces us to always handle errors from promises. We should at least log the error if it happens.