### PR TITLE
OTP2: Remove unnecessary check on searchTimeWithinRange

### DIFF
--- a/src/otp2/controller.ts
+++ b/src/otp2/controller.ts
@@ -6,7 +6,6 @@ import createEnturService, {
     Notice,
     Authority,
 } from '@entur/sdk'
-import { differenceInHours } from 'date-fns'
 import { v4 as uuid } from 'uuid'
 
 import {
@@ -220,7 +219,6 @@ export async function searchTransit(
     prevQueries?: GraphqlQuery[],
 ): Promise<TransitTripPatterns> {
     const { initialSearchDate, searchFilter, ...searchParams } = params
-    const { searchDate } = searchParams
 
     const filteredModes = filterModesAndSubModes(searchFilter)
 
@@ -237,10 +235,7 @@ export async function searchTransit(
     const parse = createParseTripPattern()
     const tripPatterns = response.map(parse).filter(isValidTransitAlternative)
 
-    const searchTimeWithinRange =
-        differenceInHours(searchDate, initialSearchDate) < 12
-
-    if (!tripPatterns.length && searchTimeWithinRange && metadata) {
+    if (!tripPatterns.length && metadata) {
         const nextSearchParams = {
             ...params,
             searchDate: new Date(metadata.nextDateTime),


### PR DESCRIPTION
Når eit søk returnerer 0 trip patterns, men me får metadata.nextDateTime, så vil me at BFFen søker framover uten å returnere til klienten.
Me hadde ein sjekk på 12 t frå originalt søketidspunkt. Denne gir ikkje meining for OTP2, og konsekvensen er at man får mange fleire round-trips mellom klient og BFF. 