### PR TITLE
Add OTP2 flexible search

### DIFF
--- a/src/otp2/controller.ts
+++ b/src/otp2/controller.ts
@@ -264,6 +264,26 @@ export async function searchTransit(
     }
 }
 
+export async function searchFlexible(
+    params: SearchParams,
+): Promise<Otp2TripPattern | undefined> {
+    const { initialSearchDate, searchFilter, ...searchParams } = params
+
+    const getTripPatternsParams = {
+        ...searchParams,
+        modes: {
+            directMode: 'flexible',
+        },
+        numTripPatterns: 1,
+    }
+
+    const [response] = await getTripPatterns(getTripPatternsParams)
+
+    const parse = createParseTripPattern()
+    const tripPatterns = response.map(parse).filter(isValidTransitAlternative)
+    return tripPatterns?.[0]
+}
+
 export type NonTransitMode = 'foot' | 'bicycle' | 'car' | 'bike_rental'
 
 export async function searchNonTransit(

--- a/src/otp2/controller.ts
+++ b/src/otp2/controller.ts
@@ -281,7 +281,7 @@ export async function searchFlexible(
 
     const parse = createParseTripPattern()
     const tripPatterns = response.map(parse).filter(isValidTransitAlternative)
-    return tripPatterns?.[0]
+    return tripPatterns[0]
 }
 
 export type NonTransitMode = 'foot' | 'bicycle' | 'car' | 'bike_rental'


### PR DESCRIPTION
Transit-søk mot OTP 2 vil utføre eit flexible-søk og putte ev. resulterande TripPattern først i lista. Dette gjer det enklare for RoR-teamet å teste og utvikle fleksible søk i OTP 2.