### PR TITLE
Remove EstimatedCall.situations from OTP 2 query

### DIFF
--- a/src/otp2/query.ts
+++ b/src/otp2/query.ts
@@ -284,8 +284,5 @@ fragment estimatedCallFields on EstimatedCall {
     serviceJourney {
         ...serviceJourneyFields
     }
-    situations {
-        ...situationFields
-    }
 }
 `)


### PR DESCRIPTION
Removes unused field that is also deprecated in latest SDK version.