### PR TITLE
Flexible search with OTP2

### DIFF
--- a/src/otp2/controller.ts
+++ b/src/otp2/controller.ts
@@ -239,8 +239,8 @@ function sortTripPatternsByExpectedTime(
 ): Otp2TripPattern[] {
     // eslint-disable-next-line fp/no-mutating-methods
     return tripPatterns.sort((a, b) => {
-        const field = arriveBy ? 'expectedEndTime' : 'expectedStartTime'
-        return a[field] < b[field] ? -1 : 1
+        if (arriveBy) return a.expectedEndTime > b.expectedEndTime ? -1 : 1
+        return a.expectedStartTime < b.expectedStartTime ? -1 : 1
     })
 }
 

--- a/src/otp2/controller.ts
+++ b/src/otp2/controller.ts
@@ -310,14 +310,11 @@ export async function searchTransit(
     const nextSearchDate = getNextSearchDate(metadata)
 
     if (flexibleResults && flexibleTripPattern && !tripPatterns.length) {
-        // Rekne ut tidsforskjellen i minutt mellom searchDate fram til flexible result [0]
-
         const searchWindow = getSearchWindow(
             flexibleTripPattern,
             nextSearchDate,
         )
 
-        // Gjere nytt transit-søk med nytt søkevindu
         const nextSearchParams = {
             ...getTripPatternsParams,
             searchDate: nextSearchDate,

--- a/src/otp2/query.ts
+++ b/src/otp2/query.ts
@@ -44,6 +44,8 @@ query (
             generalizedCost
             startTime
             endTime
+            expectedStartTime
+            expectedEndTime
             directDuration
             duration
             distance

--- a/src/otp2/query.ts
+++ b/src/otp2/query.ts
@@ -17,6 +17,7 @@ query (
     $whiteListed: InputWhiteListed,
     $debugItineraryFilter: Boolean,
     $walkReluctance: Float,
+    $searchWindow: Int,
 ) {
     trip(
         numTripPatterns: $numTripPatterns,
@@ -31,7 +32,8 @@ query (
         banned: $banned,
         whiteListed: $whiteListed,
         debugItineraryFilter: $debugItineraryFilter,
-        walkReluctance: $walkReluctance
+        walkReluctance: $walkReluctance,
+        searchWindow: $searchWindow
     ) {
         metadata {
             searchWindowUsed


### PR DESCRIPTION
Makes a flexible search in parallel with transit search when search is done through OTP 2 (`useOtp2` is true).

Flex search is made only on the initial call (when no cursor used). 
Flex results are discarded if we got transit results on the first search and the flex result departs outside the search window used by the transit call.

If we get flex results but no transit results, we make one additional transit search with a search window that is covering the time gap from the initial search date to the departure of the flex result we got.
