### PR TITLE
Don't ask for Situation.lines on OTP 2 queries

### DIFF
--- a/src/otp2/query.ts
+++ b/src/otp2/query.ts
@@ -186,9 +186,6 @@ fragment situationFields on PtSituationElement {
         language
         value
     }
-    lines {
-        ...lineFields
-    }
     validityPeriod {
         startTime
         endTime


### PR DESCRIPTION
Because of the way OTP 2 handles situations, this lines array will potentially include enormous amounts of data, which we don't really need for anything useful.

The Entur app and web clients already handles the undefined case, so we don't need to default to an empty array.