### PR TITLE
Remove flexible results that are foot only

### DIFF
--- a/src/otp2/controller.ts
+++ b/src/otp2/controller.ts
@@ -397,11 +397,17 @@ export async function searchFlexible(params: SearchParams): Promise<{
         numTripPatterns: 1,
     }
 
-    const [tripPatterns] = await getTripPatterns(getTripPatternsParams)
+    const [returnedTripPatterns] = await getTripPatterns(getTripPatternsParams)
+    const queries = [getTripPatternsQuery(getTripPatternsParams)]
+
+    const tripPatterns = returnedTripPatterns.filter(({ legs }) => {
+        const isFootOnly = legs.length === 1 && legs[0].mode === LegMode.FOOT
+        return !isFootOnly
+    })
 
     return {
         tripPatterns,
-        queries: [getTripPatternsQuery(getTripPatternsParams)],
+        queries,
     }
 }
 


### PR DESCRIPTION
Returning a foot only leg is a fallback method for directModes. But we don't want that!