### PR TITLE
Fix search window used in paginated OTP 2 calls

### DIFF
--- a/src/logic/otp2/controller.ts
+++ b/src/logic/otp2/controller.ts
@@ -49,6 +49,7 @@ interface Otp2TripPattern extends TripPattern {
 }
 
 export interface Otp2SearchParams extends Omit<SearchParams, 'modes'> {
+    searchWindow?: number
     modes: Modes
 }
 
@@ -282,7 +283,7 @@ function combineAndSortFlexibleAndTransitTripPatterns(
 }
 
 export async function searchTransit(
-    params: SearchParams,
+    params: Otp2SearchParams,
     extraHeaders: { [key: string]: string },
     prevQueries?: GraphqlQuery[],
 ): Promise<TransitTripPatterns> {
@@ -370,8 +371,9 @@ export async function searchTransit(
             ? metadata.prevDateTime
             : metadata.nextDateTime
 
-        const nextSearchParams: SearchParams = {
+        const nextSearchParams: Otp2SearchParams = {
             ...params,
+            searchWindow: metadata.searchWindowUsed,
             searchDate: parseISO(dateTime),
         }
         return searchTransit(nextSearchParams, extraHeaders, queries)
@@ -399,7 +401,7 @@ export async function searchTransit(
     }
 }
 
-async function searchFlexible(params: SearchParams): Promise<{
+async function searchFlexible(params: Otp2SearchParams): Promise<{
     tripPatterns: Otp2TripPattern[]
     queries: GraphqlQuery[]
 }> {
@@ -427,7 +429,7 @@ async function searchFlexible(params: SearchParams): Promise<{
     }
 }
 
-async function searchTaxiFrontBack(params: SearchParams): Promise<{
+async function searchTaxiFrontBack(params: Otp2SearchParams): Promise<{
     tripPatterns: Otp2TripPattern[]
     queries: GraphqlQuery[]
 }> {

--- a/src/logic/otp2/cursor.ts
+++ b/src/logic/otp2/cursor.ts
@@ -31,9 +31,9 @@ export function generateCursor(
 ): string | undefined {
     if (!metadata) return
 
-    const nextDate = new Date(
-        params.arriveBy ? metadata.prevDateTime : metadata.nextDateTime,
-    )
+    const { prevDateTime, nextDateTime, searchWindowUsed } = metadata
+
+    const nextDate = new Date(params.arriveBy ? prevDateTime : nextDateTime)
 
     const cursorData = {
         v: 1,
@@ -41,6 +41,7 @@ export function generateCursor(
             ...params,
             searchDate: nextDate,
             useFlex: false,
+            searchWindow: searchWindowUsed,
         },
     }
 

--- a/src/routes/v1/transit.ts
+++ b/src/routes/v1/transit.ts
@@ -163,6 +163,7 @@ router.post('/', async (req, res, next) => {
             res.locals.forceOtp2 ||
             (!res.locals.forceOtp1 && shouldUseOtp2(params))
         if (useOtp2) {
+            // @ts-ignore searchTransitOtp2 expects a slightly different SearchParams type
             searchMethod = searchTransitOtp2
         }
 


### PR DESCRIPTION
Now the search will use the calculated search window from the initial search in the following OTP 2 calls. This is the expected way to use the API.

If the search window is not passed a long to the next calls, a new one is calculated every time, and a consequence is that not all results are returned.