### PR TITLE
Enable taxi search on OTP 2 only if OTP 2 is forced

### DIFF
--- a/src/logic/otp1/controller.ts
+++ b/src/logic/otp1/controller.ts
@@ -58,7 +58,7 @@ export async function searchTransitWithTaxi(
         params,
         extraHeaders,
         undefined,
-        true,
+        { runOnce: true },
     )
 
     let { tripPatterns, queries } = firstTransitResults
@@ -73,7 +73,7 @@ export async function searchTransitWithTaxi(
                   firstTransitResults.nextSearchParams,
                   extraHeaders,
                   queries,
-                  true,
+                  { runOnce: true },
               )
             : undefined,
     ])
@@ -127,7 +127,7 @@ export async function searchTransit(
     params: SearchParams,
     extraHeaders: { [key: string]: string },
     prevQueries?: GraphqlQuery[],
-    runOnce = false,
+    options?: { runOnce?: boolean },
 ): Promise<TransitTripPatterns> {
     const { initialSearchDate, searchFilter, ...searchParams } = params
     const { searchDate } = searchParams
@@ -165,7 +165,7 @@ export async function searchTransit(
 
     if (!tripPatterns.length && isSameDaySearch) {
         const nextSearchParams = getNextSearchParams(params)
-        if (!runOnce) {
+        if (!options?.runOnce) {
             return searchTransit(nextSearchParams, extraHeaders, queries)
         }
         return {

--- a/src/logic/otp2/controller.ts
+++ b/src/logic/otp2/controller.ts
@@ -29,7 +29,7 @@ import { isValidTransitAlternative } from '../../utils/tripPattern'
 import { parseLeg } from '../../utils/leg'
 import { replaceQuay1ForOsloSWithUnknown } from '../../utils/osloSTrack1Replacer'
 
-import { ENVIRONMENT, TRANSIT_HOST_OTP2 } from '../../config'
+import { TRANSIT_HOST_OTP2 } from '../../config'
 
 import JOURNEY_PLANNER_QUERY from './query'
 import { filterModesAndSubModes, Mode } from './modes'
@@ -286,6 +286,7 @@ export async function searchTransit(
     params: Otp2SearchParams,
     extraHeaders: { [key: string]: string },
     prevQueries?: GraphqlQuery[],
+    options?: { enableTaxiSearch?: boolean },
 ): Promise<TransitTripPatterns> {
     const { initialSearchDate, searchFilter, ...searchParams } = params
     const { searchDate, arriveBy } = searchParams
@@ -301,7 +302,7 @@ export async function searchTransit(
             initialSearchDate === searchDate
                 ? searchFlexible(params)
                 : undefined,
-            ENVIRONMENT !== 'prod' && initialSearchDate === searchDate
+            options?.enableTaxiSearch && initialSearchDate === searchDate
                 ? searchTaxiFrontBack(params)
                 : undefined,
             getTripPatterns(getTripPatternsParams),

--- a/src/routes/v1/transit.ts
+++ b/src/routes/v1/transit.ts
@@ -159,6 +159,12 @@ router.post('/', async (req, res, next) => {
         }
 
         let searchMethod = cursorData ? searchTransit : searchTransitWithTaxi
+        const searchOptions: { runOnce?: boolean; enableTaxiSearch?: boolean } =
+            {
+                enableTaxiSearch:
+                    ENVIRONMENT !== 'prod' && res.locals.forceOtp2 === true,
+            }
+
         const useOtp2 =
             res.locals.forceOtp2 ||
             (!res.locals.forceOtp1 && shouldUseOtp2(params))
@@ -178,7 +184,7 @@ router.post('/', async (req, res, next) => {
             cursorData ? 'searchTransit' : 'searchTransitWithTaxi',
         )
         const { tripPatterns, metadata, hasFlexibleTripPattern, queries } =
-            await searchMethod(params, extraHeaders)
+            await searchMethod(params, extraHeaders, undefined, searchOptions)
         stopTrace()
 
         if (!cursorData) {


### PR DESCRIPTION
This will not show weird taxi results under normal testing, but it
is still easy to test taxi searches in OTP 2 by forcing it through
Dev Settings.
We can probably enable this by default when RoR has done more
tweaking of taxi searches.