### PR TITLE
Limit consecutive calls to JourneyPlanner to a max of 15

### DIFF
--- a/src/logic/otp2/controller.ts
+++ b/src/logic/otp2/controller.ts
@@ -368,6 +368,15 @@ export async function searchTransit(
     ]
 
     if (!tripPatterns.length && metadata) {
+        if (queries.length > 15) {
+            return {
+                tripPatterns: [],
+                metadata: undefined,
+                hasFlexibleTripPattern: false,
+                queries,
+            }
+        }
+
         const dateTime = arriveBy
             ? metadata.prevDateTime
             : metadata.nextDateTime


### PR DESCRIPTION
If JourneyPlanner keeps returning no results, but metadata with a
small time offset, we would just continue calling the API until 7
days ahead of search time was reached. If every call is just one
hour different than the one before, this means a lot of calls, and
Google App Engine times out. A limit of 15 consecutive, resultless
calls prevents this.

Searches where 'from' and 'to' are very close could trigger this.