### PR TITLE
quay id and aimedDepartureTime to determine if same call when updating trip pattern

### DIFF
--- a/src/logic/otp1/updateTrip.ts
+++ b/src/logic/otp1/updateTrip.ts
@@ -85,7 +85,7 @@ async function getCallsForServiceJourney(
     return data.serviceJourney.estimatedCalls
 }
 
-function createCallPredicate(
+function createIsSameCallPredicate(
     call: EstimatedCall,
 ): (updatedCall: UpdatedEstimatedCall) => boolean {
     const { aimedDepartureTime } = call
@@ -151,13 +151,13 @@ async function updateLeg(leg: Leg): Promise<LegWithUpdate> {
     )
 
     const fromIndex = updatedEstimatedCalls.findIndex(
-        createCallPredicate(fromEstimatedCall),
+        createIsSameCallPredicate(fromEstimatedCall),
     )
     const fromCall = updatedEstimatedCalls[fromIndex]
     if (!fromCall) return { leg }
 
     const toIndex = updatedEstimatedCalls.findIndex(
-        createCallPredicate(toEstimatedCall),
+        createIsSameCallPredicate(toEstimatedCall),
     )
     const toCall = updatedEstimatedCalls[toIndex]
     if (!toCall) return { leg }
@@ -199,7 +199,7 @@ function updateTransitLeg(leg: Leg, updatedCalls: UpdatedCalls): Leg {
     const updatedIntermediateEstimatedCalls = intermediateEstimatedCalls.map(
         (call) => {
             const updatedCall = intermediateCalls.find(
-                createCallPredicate(call),
+                createIsSameCallPredicate(call),
             )
             return updateEstimatedCall(call, updatedCall)
         },

--- a/src/logic/otp1/updateTrip.ts
+++ b/src/logic/otp1/updateTrip.ts
@@ -35,7 +35,6 @@ interface UpdatedEstimatedCall {
     aimedDepartureTime: string
     actualArrivalTime: string | undefined
     actualDepartureTime: string | undefined
-    destinationDisplay: { frontText: string }
     notices: {
         id: string
     }
@@ -66,9 +65,6 @@ async function getCallsForServiceJourney(
                 aimedDepartureTime
                 actualDepartureTime
                 actualArrivalTime
-                destinationDisplay {
-                    frontText
-                }
                 notices {
                     id
                 }
@@ -89,36 +85,15 @@ async function getCallsForServiceJourney(
     return data.serviceJourney.estimatedCalls
 }
 
-function isSameCall(
-    estimatedCall: UpdatedEstimatedCall,
-    quayId: string,
-    destinationFrontText?: string,
-): boolean {
-    const { quay, destinationDisplay } = estimatedCall
-    return destinationFrontText
-        ? quay.id === quayId &&
-              destinationDisplay.frontText === destinationFrontText
-        : quay.id === quayId
-}
-
-function findCallByQuayId(
-    estimatedCalls: UpdatedEstimatedCall[],
-    quayId: string,
-    destinationFrontText?: string,
-): UpdatedEstimatedCall | undefined {
-    return estimatedCalls.find((call) =>
-        isSameCall(call, quayId, destinationFrontText),
-    )
-}
-
-function findCallIndexByQuayId(
-    estimatedCalls: UpdatedEstimatedCall[],
-    quayId: string,
-    destinationFrontText?: string,
-): number {
-    return estimatedCalls.findIndex((call) =>
-        isSameCall(call, quayId, destinationFrontText),
-    )
+function createCallPredicate(
+    call: EstimatedCall,
+): (updatedCall: UpdatedEstimatedCall) => boolean {
+    const { aimedDepartureTime } = call
+    const quayId = call.quay?.id
+    if (!quayId) return () => false
+    return (updatedCall: UpdatedEstimatedCall) =>
+        updatedCall.quay?.id === quayId &&
+        updatedCall.aimedDepartureTime === aimedDepartureTime
 }
 
 function updateEstimatedCall(
@@ -175,25 +150,15 @@ async function updateLeg(leg: Leg): Promise<LegWithUpdate> {
         fromEstimatedCall.date,
     )
 
-    const fromFrontText = fromEstimatedCall.destinationDisplay?.frontText
-    const fromQuayId = fromEstimatedCall.quay?.id || ''
-    const fromIndex = findCallIndexByQuayId(
-        updatedEstimatedCalls,
-        fromQuayId,
-        fromFrontText,
+    const fromIndex = updatedEstimatedCalls.findIndex(
+        createCallPredicate(fromEstimatedCall),
     )
     const fromCall = updatedEstimatedCalls[fromIndex]
     if (!fromCall) return { leg }
 
-    const toFrontText = toEstimatedCall.destinationDisplay?.frontText
-    const toQuayId = toEstimatedCall.quay?.id || ''
-
-    const remainingUpdatedCalls = updatedEstimatedCalls.slice(fromIndex + 1)
-
-    const toIndex =
-        findCallIndexByQuayId(remainingUpdatedCalls, toQuayId, toFrontText) +
-        fromIndex +
-        1
+    const toIndex = updatedEstimatedCalls.findIndex(
+        createCallPredicate(toEstimatedCall),
+    )
     const toCall = updatedEstimatedCalls[toIndex]
     if (!toCall) return { leg }
 
@@ -233,13 +198,8 @@ function updateTransitLeg(leg: Leg, updatedCalls: UpdatedCalls): Leg {
 
     const updatedIntermediateEstimatedCalls = intermediateEstimatedCalls.map(
         (call) => {
-            if (!call.quay || !call.quay.id) return call
-            const frontText = call.destinationDisplay?.frontText
-            const quayId = call.quay.id
-            const updatedCall = findCallByQuayId(
-                intermediateCalls,
-                quayId,
-                frontText,
+            const updatedCall = intermediateCalls.find(
+                createCallPredicate(call),
             )
             return updateEstimatedCall(call, updatedCall)
         },

--- a/src/logic/otp2/updateTrip.ts
+++ b/src/logic/otp2/updateTrip.ts
@@ -85,7 +85,7 @@ async function getCallsForServiceJourney(
     return data.serviceJourney.estimatedCalls
 }
 
-function createCallPredicate(
+function createIsSameCallPredicate(
     call: EstimatedCall,
 ): (updatedCall: UpdatedEstimatedCall) => boolean {
     const { aimedDepartureTime } = call
@@ -151,13 +151,13 @@ async function updateLeg(leg: Leg): Promise<LegWithUpdate> {
     )
 
     const fromIndex = updatedEstimatedCalls.findIndex(
-        createCallPredicate(fromEstimatedCall),
+        createIsSameCallPredicate(fromEstimatedCall),
     )
     const fromCall = updatedEstimatedCalls[fromIndex]
     if (!fromCall) return { leg }
 
     const toIndex = updatedEstimatedCalls.findIndex(
-        createCallPredicate(toEstimatedCall),
+        createIsSameCallPredicate(toEstimatedCall),
     )
     const toCall = updatedEstimatedCalls[toIndex]
     if (!toCall) return { leg }
@@ -199,7 +199,7 @@ function updateTransitLeg(leg: Leg, updatedCalls: UpdatedCalls): Leg {
     const updatedIntermediateEstimatedCalls = intermediateEstimatedCalls.map(
         (call) => {
             const updatedCall = intermediateCalls.find(
-                createCallPredicate(call),
+                createIsSameCallPredicate(call),
             )
             return updateEstimatedCall(call, updatedCall)
         },


### PR DESCRIPTION
Sometimes a bus visits a stop place more than once per service journey. Change the update trip pattern methods to handle this corner case. 

![image](https://user-images.githubusercontent.com/506895/135895934-82a45791-cafd-48d7-9d4c-a1411a95e87e.png)
