### PR TITLE
Add maximumWaitTime to Interchange in otp2 query

### DIFF
--- a/src/logic/otp2/query.ts
+++ b/src/logic/otp2/query.ts
@@ -253,6 +253,7 @@ fragment serviceJourneyFields on ServiceJourney {
 fragment interchangeFields on Interchange {
     guaranteed
     staySeated
+    maximumWaitTime
     fromServiceJourney {
         id
     }


### PR DESCRIPTION
Clients need maximumWaitTime to generate message for guaranteed connections