### PR TITLE
Better flow in code

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -35,7 +35,7 @@ export async function get<T>(
 ): Promise<T | null> {
     const entry = await hgetall(key)
 
-    if (entry === null) {
+    if (entry === null || entry.data === undefined) {
         return null
     }
     await expire(key, expireInSeconds)

--- a/src/logic/otp1/controller.ts
+++ b/src/logic/otp1/controller.ts
@@ -308,7 +308,7 @@ async function searchTaxiFrontBack(
         ),
     ])
 
-    return [...pickup, ...dropoff].filter(
+    return [...(pickup || []), ...(dropoff || [])].filter(
         isValidTaxiAlternative(
             initialSearchDate,
             car,

--- a/src/logic/otp2/controller.ts
+++ b/src/logic/otp2/controller.ts
@@ -609,7 +609,7 @@ export async function searchTransit(
     const noStopsInRangeErrors = routingErrors.filter(
         ({ code }) => code === RoutingErrorCode.noStopsInRange,
     )
-    const hasStopsInRange = noStopsInRangeErrors.length > 0
+    const hasStopsInRange = noStopsInRangeErrors.length === 0
     let taxiTripPatterns: Otp2TripPattern[] = []
     if (!hasStopsInRange) {
         const noFromStopInRange = noStopsInRangeErrors.some(

--- a/src/logic/otp2/controller.ts
+++ b/src/logic/otp2/controller.ts
@@ -191,12 +191,13 @@ function getNotices(leg: Leg): Notice[] {
 }
 
 function authorityMapper(authority?: Authority): Authority | undefined {
-    if (!authority) return undefined
+    const codeSpace = authority?.id.split(':')[0]
+    if (!authority || !codeSpace) return undefined
 
     return {
         id: authority.id,
         name: authority.name,
-        codeSpace: authority.id.split(':')[0] || '',
+        codeSpace,
         url: authority.url,
     }
 }

--- a/src/logic/otp2/controller.ts
+++ b/src/logic/otp2/controller.ts
@@ -573,17 +573,19 @@ export async function searchTransit(
     const nextSearchDateFromMetadata =
         metadata && getNextSearchDateFromMetadata(metadata, arriveBy)
 
+    // Flexible may return results in the future that are outside the
+    // original search window. There may still exist normal transport in the
+    // time between the search window end and the first suggested flexible
+    // result. For example, if  the search window ends on midnight Friday, and
+    // the first suggested flexible result is on Monday morning, we can probably
+    // still find a normal transport option on Saturday.
+
+    // To find these so we do a new search if we found no regular trip patterns
+    // within the original search window.
     const flexibleTripPattern = flexibleResults.tripPatterns[0]
     const hasFlexibleResultsOnly =
         flexibleTripPattern && !regularTripPatterns.length
     if (hasFlexibleResultsOnly) {
-        // Flexible may return results in the future that are outside the
-        // original search window. There may still exist normal transport in the
-        // time between the search window end and the first suggested flexible
-        // result, so we do a new search to try to find those. For example, if
-        // the search window ends on midnight Friday, and the first suggested
-        // flexible result is on Monday morning, we can probably still find a
-        // normal transport option on Saturday.
         const beforeFlexibleResult = await searchBeforeFlexible(
             nextSearchDateFromMetadata || searchDate,
             arriveBy,

--- a/src/logic/otp2/controller.ts
+++ b/src/logic/otp2/controller.ts
@@ -440,9 +440,10 @@ export async function searchTransitUntilMaxRetries(
  * when the service starts again.
  *
  * This is kind of a catch, as there may be other, better suggestions using
- * normal transport in the time between your search window - for example, if
- * your normal search window ends Friday at midnight, there still may be
- * transport available all of Saturday. This must be handled separately.
+ * normal transport in the time between your search window and the flexible
+ * suggestion - for example, if your normal search window ends Friday at
+ * midnight, there still may be transport available all of Saturday. This must
+ * be handled separately.
  */
 async function searchFlexible(searchParams: Otp2GetTripPatternParams): Promise<{
     tripPatterns: Otp2TripPattern[]

--- a/src/logic/otp2/controller.ts
+++ b/src/logic/otp2/controller.ts
@@ -105,6 +105,7 @@ function parseTripPattern(rawTripPattern: any): Otp2TripPattern {
     }
 }
 
+// TODO Why is this duplicated from modes.ts? and a shorter list?
 type StreetMode =
     | 'foot'
     | 'bicycle'
@@ -115,6 +116,7 @@ type StreetMode =
     | 'taxi'
     | 'car_rental'
 
+// TODO Why is this duplicated from modes.ts?
 interface Modes {
     accessMode: StreetMode
     egressMode: StreetMode
@@ -122,6 +124,7 @@ interface Modes {
     transportModes: Mode[]
 }
 
+// TODO Why is this duplicated from modes.ts but shorter?
 const DEFAULT_MODES: Modes = {
     accessMode: 'foot',
     egressMode: 'foot',
@@ -462,7 +465,7 @@ export async function searchTransit(
     // reach the maximum retries/maximum days back/forwards
     return searchTransitUntilMaxRetries(
         initialSearchDate,
-        getTripPatternsParams,
+        getTripPatternsParams, // TODO: This doesn't work because types are duplicated
         extraHeaders,
         queries,
     )
@@ -541,7 +544,7 @@ export async function searchTransitUntilMaxRetries(
             // any trip patterns. Give up.
             return {
                 tripPatterns: [],
-                metadata,
+                metadata, // TODO: Metadata will be undefined here but this code is copied from master
                 hasFlexibleTripPattern: false,
                 queries,
             }

--- a/src/logic/otp2/controller.ts
+++ b/src/logic/otp2/controller.ts
@@ -5,7 +5,7 @@ import createEnturService, {
     Leg,
     Notice,
     Authority,
-    TransportMode,
+    GetTripPatternsParams,
 } from '@entur/sdk'
 import { v4 as uuid } from 'uuid'
 import {
@@ -35,7 +35,7 @@ import { TRANSIT_HOST_OTP2 } from '../../config'
 import { GetTripPatternError, RoutingErrorsError } from '../../errors'
 
 import JOURNEY_PLANNER_QUERY from './query'
-import { filterModesAndSubModes, Mode } from './modes'
+import { DEFAULT_MODES, filterModesAndSubModes, Modes } from './modes'
 
 const sdk = createEnturService({
     clientName: 'entur-search',
@@ -51,18 +51,18 @@ interface Otp2TripPattern extends TripPattern {
     }[]
 }
 
-interface Otp2SearchParams extends Omit<SearchParams, 'modes'> {
+interface AdditionalOtp2TripPatternParams {
     searchWindow?: number
     modes: Modes
 }
 
-// The stuff we actually send to journey planner
-// TODO: This should probably be directly based on GetTripPatternsParams, unless we need anything inbetween:
-// - cursor, searchFilter, searchDate, initialSearchDate, searchWindow, modes (different from the SDK one)
-type Otp2BackendSearchParams = Omit<
-    Otp2SearchParams,
-    'initialSearchDate' | 'searchFilter'
->
+// function signature type, to match signature for OTP1 searchTransit.
+type Otp2SearchParams = Omit<SearchParams, 'modes'> &
+    AdditionalOtp2TripPatternParams
+
+// GetTripPatternsParams is an OTP1 type, we need to tweak it to match OTP2
+type Otp2GetTripPatternParams = Omit<GetTripPatternsParams, 'modes'> &
+    AdditionalOtp2TripPatternParams
 
 interface TransitTripPatterns {
     tripPatterns: Otp2TripPattern[]
@@ -71,7 +71,7 @@ interface TransitTripPatterns {
     metadata?: Metadata
 }
 
-// If any of these routing errors are received, there is no point in continuing the search.
+// There is no point in continuing the search if any of these routing errors are received
 const HOPELESS_ROUTING_ERRORS = [
     RoutingErrorCode.noTransitConnection,
     RoutingErrorCode.outsideServicePeriod,
@@ -107,40 +107,7 @@ function parseTripPattern(rawTripPattern: any): Otp2TripPattern {
     }
 }
 
-// TODO Why is this duplicated from modes.ts? and a shorter list?
-type StreetMode =
-    | 'foot'
-    | 'bicycle'
-    | 'bike_park'
-    | 'bike_rental'
-    | 'car'
-    | 'car_park'
-    | 'taxi'
-    | 'car_rental'
-
-// TODO Why is this duplicated from modes.ts?
-interface Modes {
-    accessMode: StreetMode
-    egressMode: StreetMode
-    directMode?: StreetMode
-    transportModes: Mode[]
-}
-
-// TODO Why is this duplicated from modes.ts but shorter?
-const DEFAULT_MODES: Modes = {
-    accessMode: 'foot',
-    egressMode: 'foot',
-    transportModes: [
-        { transportMode: TransportMode.BUS },
-        { transportMode: TransportMode.TRAM },
-        { transportMode: TransportMode.RAIL },
-        { transportMode: TransportMode.METRO },
-        { transportMode: TransportMode.WATER },
-        { transportMode: TransportMode.AIR },
-    ],
-}
-
-function getTripPatternsVariables(params: any): any {
+function getTripPatternsVariables(params: Otp2GetTripPatternParams): any {
     const {
         from,
         to,
@@ -162,7 +129,7 @@ function getTripPatternsVariables(params: any): any {
     }
 }
 
-function getTripPatternsQuery(params: Record<string, unknown>): GraphqlQuery {
+function getTripPatternsQuery(params: Otp2GetTripPatternParams): GraphqlQuery {
     return {
         query: JOURNEY_PLANNER_QUERY,
         variables: getTripPatternsVariables(params),
@@ -325,13 +292,15 @@ function combineAndSortFlexibleAndTransitTripPatterns(
     return sortedTripPatterns
 }
 
+// Search for results in the time between the end of a search window and the first available flexible trip. This is
+// necessary as we may get a flexible trip suggestion a few days in the future. Normal transport may be available
+// in that time period that would be a better suggestion to the traveler.
 async function searchBeforeFlexible(
     searchDate: Date,
     arriveBy = false,
     flexibleTripPattern: Otp2TripPattern,
     searchParams: any,
 ): Promise<TransitTripPatterns> {
-    // TODO: What is changed here, increased range?
     const searchWindow = getMinutesBetweenDates(
         parseISO(
             arriveBy
@@ -366,7 +335,7 @@ async function searchBeforeFlexible(
 
 export async function searchTransitUntilMaxRetries(
     initialSearchDate: Date,
-    searchParams: Otp2BackendSearchParams,
+    searchParams: Otp2GetTripPatternParams,
     extraHeaders: { [key: string]: string },
     prevQueries: GraphqlQuery[],
 ): Promise<TransitTripPatterns> {
@@ -392,20 +361,22 @@ export async function searchTransitUntilMaxRetries(
 
     // Metadata will be null if routingErrors is not empty, because searchWindow cannot be
     // calculated.
+    //
+    // When we have metadata, we limit by the number of queries as each result may only be for parts of a day.
+    // Queries where metadata is missing is limited by a set number of days, and each query spans a full day, as we
+    // have no information about the next search window to use.
     if (metadata) {
-        // TODO: Why do we use 15 queries here but not when we don't have metadata?
         if (queries.length > 15) {
             // We have tried as many times as we should but could not find
             // any trip patterns. Give up.
             return {
                 tripPatterns: [],
-                metadata: undefined, // TODO: Why is metadata undefined here
+                metadata: undefined, // TODO: Why is metadata undefined here - Kanskje for å stoppe cursor-generering? Sjekk kode.
                 hasFlexibleTripPattern: false,
                 queries,
             }
         }
 
-        // TODO: What is changed here, backwards/forwards in time
         const dateTime = arriveBy
             ? metadata.prevDateTime
             : metadata.nextDateTime
@@ -416,8 +387,6 @@ export async function searchTransitUntilMaxRetries(
             searchDate: parseISO(dateTime),
         }
 
-        // TODO: We should split out the parts of searchTransit that only run the first
-        // time and have a cleaner method body that does not need all the checks
         return searchTransitUntilMaxRetries(
             initialSearchDate,
             nextSearchParams,
@@ -426,16 +395,15 @@ export async function searchTransitUntilMaxRetries(
         )
     } else {
         const nextMidnight = arriveBy
-            ? endOfDay(subDays(searchDate, 1))
-            : startOfDay(addDays(searchDate, 1))
+            ? endOfDay(subDays(searchDate || new Date(), 1))
+            : startOfDay(addDays(searchDate || new Date(), 1))
 
-        // TODO: Why do we use 7 here but not above?
         if (Math.abs(differenceInDays(nextMidnight, initialSearchDate)) >= 7) {
             // We have tried as far back as we should but could not find
             // any trip patterns. Give up.
             return {
                 tripPatterns: [],
-                metadata, // TODO: Metadata will be undefined here but this code is copied from master
+                metadata: undefined,
                 hasFlexibleTripPattern: false,
                 queries,
             }
@@ -455,13 +423,26 @@ export async function searchTransitUntilMaxRetries(
     }
 }
 
-async function searchFlexible(searchParams: Otp2BackendSearchParams): Promise<{
+// A flexible search includes modes of transport (bus or other) where the traveler has to book a call in advance -
+// if not, the bus may either drive past or not show up at all.
+//
+// Such services do not run at all hours of the day, but we will still return the first available match, even if it
+// is outside the requested search window.
+//
+// For example, if you do a search on a Friday evening at 8pm, but the service is not available after 6pm, you may
+// get a suggestion Monday morning at 8am when the service starts again.
+//
+// This is kind of a catch, as there may be other, better suggestions using normal transport in the time between
+// your search window - for example, if your normal search window ends Friday at midnight, there still may be
+// transport available all of Saturday. This must be handled separately.
+async function searchFlexible(searchParams: Otp2GetTripPatternParams): Promise<{
     tripPatterns: Otp2TripPattern[]
     queries: GraphqlQuery[]
 }> {
     const getTripPatternsParams = {
         ...searchParams,
         modes: {
+            transportModes: [],
             directMode: 'flexible',
         },
         numTripPatterns: 1,
@@ -498,7 +479,7 @@ async function searchFlexible(searchParams: Otp2BackendSearchParams): Promise<{
 }
 
 async function searchTaxiFrontBack(
-    searchParams: Otp2BackendSearchParams,
+    searchParams: Otp2GetTripPatternParams,
     options: { access: boolean; egress: boolean },
 ): Promise<TransitTripPatterns> {
     const { access, egress } = options
@@ -516,11 +497,9 @@ async function searchTaxiFrontBack(
     const [tripPatterns] = await getTripPatterns(getTripPatternsParams)
     const queries = [getTripPatternsQuery(getTripPatternsParams)]
 
-    /**
-     * If no access or egress leg is necessary, we can get trip patterns with
-     * no car legs. We therefore filter the results to prevent it from
-     * returning results that the normal search also might return.
-     */
+    // If no access or egress leg is necessary, we can get trip patterns with
+    // no car legs. We therefore filter the results to prevent it from
+    // returning results that the normal search also might return.
     const taxiResults = tripPatterns.filter(({ legs }) =>
         legs.some(({ mode }) => mode === LegMode.CAR),
     )
@@ -531,36 +510,40 @@ async function searchTaxiFrontBack(
     }
 }
 
+// TODO 7/12-21: Clean up function signature and types once OTP1 is gone.
+// As we have removed recursion, initialSearchDate can be replaced with searchDate. searchFilter could
+// be kept separate from Otp2SearchParams.
 export async function searchTransit(
-    // TODO initialSearchDate and searchFilter should be completely separate.
     { initialSearchDate, searchFilter, ...searchParams }: Otp2SearchParams,
     extraHeaders: { [key: string]: string },
-    // TODO This should be removed but is part of the interface at the moment.
-    completelyUnusedParameter: undefined,
-    options: { enableTaxiSearch?: boolean },
 ): Promise<TransitTripPatterns> {
     const { searchDate, arriveBy } = searchParams
 
-    // TODO: Unless we forward modes to journeyPlanner, we should split this object?
     const getTripPatternsParams = {
         ...searchParams,
         modes: filterModesAndSubModes(searchFilter),
     }
 
-    // TODO: Explain to joakim why are we doing two searches, what does flexible do
     const [flexibleResults, [response, initialMetadata, routingErrors]] =
         await Promise.all([
             searchFlexible(searchParams),
             getTripPatterns(getTripPatternsParams),
         ])
+
+    let queries = [
+        ...flexibleResults.queries,
+        getTripPatternsQuery(getTripPatternsParams),
+    ]
+
     let metadata = initialMetadata
 
     const noStopsInRangeErrors = routingErrors.filter(
         ({ code }) => code === RoutingErrorCode.noStopsInRange,
     )
 
+    // TODO: will we have any results above or could we just return taxiResults if we find any?
     let taxiResults: TransitTripPatterns | undefined
-    if (options.enableTaxiSearch && noStopsInRangeErrors.length > 0) {
+    if (noStopsInRangeErrors.length > 0) {
         const noFromStopInRange = noStopsInRangeErrors.some(
             (e) => e.inputField === 'from',
         )
@@ -572,6 +555,7 @@ export async function searchTransit(
             access: noFromStopInRange,
             egress: noToStopInRange,
         })
+        queries = [...taxiResults.queries]
     }
 
     let tripPatterns = response
@@ -580,22 +564,20 @@ export async function searchTransit(
         // customers keep getting stuck on the wrong platform (31st of May 2021)
         .map(replaceQuay1ForOsloSWithUnknown)
 
-    // TODO: Spiller rekkefølgen her noen rolle??? For det første så UTFØRER vi det i en annen rekkefølge,
-    // for det andre legger vi ting i resultatlisten i en tredje rekkefølge.
-    let queries = [
-        ...flexibleResults.queries,
-        ...(taxiResults?.queries || []),
-        getTripPatternsQuery(getTripPatternsParams),
-    ]
-
     const nextSearchDateFromMetadata = metadata
         ? getNextSearchDateFromMetadata(metadata, arriveBy)
         : undefined
 
     // TODO: Why does not TypeScript say that this is possibly undefined?
+    // TODO: Kanskje skru på ts-config undefined her?
     const flexibleTripPattern = flexibleResults.tripPatterns[0]
     const hasFlexibleResultsOnly = flexibleTripPattern && !tripPatterns.length
     if (hasFlexibleResultsOnly) {
+        // Flexible may return results in the future that are outside the original search window. There may still
+        // exist normal transport in the time between the search window end and the first suggested flexible result,
+        // so we do a new search to try to find those. For example, if the search window ends on midnight Friday,
+        // and the first suggested flexible result is on Monday morning, we can probably still find a normal transport
+        // option on Saturday.
         const beforeFlexibleResult = await searchBeforeFlexible(
             nextSearchDateFromMetadata || searchDate,
             arriveBy,
@@ -623,7 +605,7 @@ export async function searchTransit(
         return {
             tripPatterns,
             metadata,
-            hasFlexibleTripPattern: Boolean(flexibleTripPattern),
+            hasFlexibleTripPattern: Boolean(flexibleTripPattern), // TODO: Sjekk om dette er legacy og om vi kan fjerne.
             queries,
         }
     }
@@ -632,7 +614,7 @@ export async function searchTransit(
     // reach the maximum retries/maximum days back/forwards
     return searchTransitUntilMaxRetries(
         initialSearchDate,
-        getTripPatternsParams, // TODO: This doesn't work because types are duplicated
+        getTripPatternsParams,
         extraHeaders,
         queries,
     )
@@ -659,8 +641,6 @@ export async function searchNonTransit(
                 limit: 1,
                 allowBikeRental: mode === 'bike_rental',
                 modes: {
-                    accessMode: null,
-                    egressMode: null,
                     directMode: mode,
                     transportModes: [],
                 },

--- a/src/logic/otp2/controller.ts
+++ b/src/logic/otp2/controller.ts
@@ -354,7 +354,6 @@ export async function searchTransitUntilMaxRetries(
         return {
             tripPatterns,
             metadata,
-            hasFlexibleTripPattern: false,
             queries,
         }
     }
@@ -372,7 +371,6 @@ export async function searchTransitUntilMaxRetries(
             return {
                 tripPatterns: [],
                 metadata: undefined, // TODO: Why is metadata undefined here - Kanskje for å stoppe cursor-generering? Sjekk kode.
-                hasFlexibleTripPattern: false,
                 queries,
             }
         }
@@ -478,6 +476,12 @@ async function searchFlexible(searchParams: Otp2GetTripPatternParams): Promise<{
     }
 }
 
+// Have you ever wondered what access or egress means? Well, you're lucky - here's the definition for you:
+// - access - the means or opportunity to approach or enter a place
+// - egress - the action of going out of or leaving a place.
+//
+// So if access is true, try to find a taxi at the start of the trip, if egress is true, do the same at the
+// end of the trip. Domain specific language is fun!
 async function searchTaxiFrontBack(
     searchParams: Otp2GetTripPatternParams,
     options: { access: boolean; egress: boolean },
@@ -524,6 +528,9 @@ export async function searchTransit(
         modes: filterModesAndSubModes(searchFilter),
     }
 
+    // We do two searches in parallel here to speed things up a bit. One is a flexible search where
+    // we explicitly look for trips that may include means of transport that has to be booked in advance, the second
+    // is a normal search.
     const [flexibleResults, [response, initialMetadata, routingErrors]] =
         await Promise.all([
             searchFlexible(searchParams),
@@ -541,7 +548,8 @@ export async function searchTransit(
         ({ code }) => code === RoutingErrorCode.noStopsInRange,
     )
 
-    // TODO: will we have any results above or could we just return taxiResults if we find any?
+    // If we have any noStopsInRange errors, we couldn't find a means of transport from where the
+    // traveler wants to start or end the trip. Try to find an option using taxi for those parts instead.
     let taxiResults: TransitTripPatterns | undefined
     if (noStopsInRangeErrors.length > 0) {
         const noFromStopInRange = noStopsInRangeErrors.some(

--- a/src/logic/otp2/modes.ts
+++ b/src/logic/otp2/modes.ts
@@ -3,7 +3,7 @@ import { uniq } from '../../utils/array'
 import { SearchFilter } from '../../types'
 import { ALL_BUS_SUBMODES, ALL_RAIL_SUBMODES } from '../../constants'
 
-export declare enum StreetMode {
+export enum StreetMode {
     FOOT = 'foot',
     BICYCLE = 'bicycle',
     BIKE_PARK = 'bike_park',

--- a/src/logic/otp2/modes.ts
+++ b/src/logic/otp2/modes.ts
@@ -3,17 +3,18 @@ import { uniq } from '../../utils/array'
 import { SearchFilter } from '../../types'
 import { ALL_BUS_SUBMODES, ALL_RAIL_SUBMODES } from '../../constants'
 
-export type StreetMode =
-    | 'foot'
-    | 'bicycle'
-    | 'bike_park'
-    | 'bike_rental'
-    | 'car'
-    | 'car_park'
-    | 'taxi'
-    | 'car_rental'
-    | 'car_pickup'
-    | 'flexible'
+export declare enum StreetMode {
+    FOOT = 'foot',
+    BICYCLE = 'bicycle',
+    BIKE_PARK = 'bike_park',
+    BIKE_RENTAL = 'bike_rental',
+    CAR = 'car',
+    CAR_PARK = 'car_park',
+    TAXI = 'taxi',
+    CAR_RENTAL = 'car_rental',
+    CAR_PICKUP = 'car_pickup',
+    FLEXIBLE = 'flexible',
+}
 
 export interface Mode {
     transportMode: TransportMode
@@ -28,8 +29,8 @@ export interface Modes {
 }
 
 export const DEFAULT_MODES: Modes = {
-    accessMode: 'foot',
-    egressMode: 'foot',
+    accessMode: StreetMode.FOOT,
+    egressMode: StreetMode.FOOT,
     transportModes: [
         { transportMode: TransportMode.BUS },
         { transportMode: TransportMode.TRAM },

--- a/src/logic/otp2/modes.ts
+++ b/src/logic/otp2/modes.ts
@@ -13,6 +13,7 @@ export type StreetMode =
     | 'taxi'
     | 'car_rental'
     | 'car_pickup'
+    | 'flexible'
 
 export interface Mode {
     transportMode: TransportMode
@@ -20,8 +21,8 @@ export interface Mode {
 }
 
 export interface Modes {
-    accessMode: StreetMode
-    egressMode: StreetMode
+    accessMode?: StreetMode
+    egressMode?: StreetMode
     directMode?: StreetMode
     transportModes: Mode[]
 }

--- a/src/routes/v1/transit.ts
+++ b/src/routes/v1/transit.ts
@@ -91,7 +91,7 @@ router.post('/', async (req, res, next) => {
 
         const params = cursorData?.params || getParams(req.body)
         const extraHeaders = getHeadersFromClient(req)
-        const clientName = extraHeaders['ET-Client-Name']
+        const clientName = extraHeaders['ET-Client-Name'] || 'Unknown client'
 
         if (cursorData) {
             // Restrict flex results only to the initial search

--- a/src/routes/v1/transit.ts
+++ b/src/routes/v1/transit.ts
@@ -114,8 +114,15 @@ router.post('/', async (req, res, next) => {
         stopTrace = trace(
             cursorData ? 'searchTransit' : 'searchTransitWithTaxi',
         )
-        const { tripPatterns, metadata, hasFlexibleTripPattern, queries } =
-            await searchMethod(params, extraHeaders)
+
+        // OTP2 does not return hasFlexibleTripPattern, but we still have
+        // to return it because old versions of the app require it for logging
+        const {
+            tripPatterns,
+            metadata,
+            hasFlexibleTripPattern = false,
+            queries,
+        } = await searchMethod(params, extraHeaders)
         stopTrace()
 
         if (!cursorData) {

--- a/src/routes/v1/transit.ts
+++ b/src/routes/v1/transit.ts
@@ -99,14 +99,9 @@ router.post('/', async (req, res, next) => {
         }
 
         let searchMethod = cursorData ? searchTransit : searchTransitWithTaxi
-        const searchOptions: { runOnce?: boolean; enableTaxiSearch?: boolean } =
-            {
-                enableTaxiSearch: ENVIRONMENT !== 'prod',
-            }
 
         useOtp2 = !res.locals.forceOtp1
 
-        //TODO: Hvorfor er denne her og ikke før vi setter searchMethod????
         if (useOtp2) {
             // @ts-ignore searchTransitOtp2 expects a slightly different SearchParams type
             searchMethod = searchTransitOtp2
@@ -120,7 +115,7 @@ router.post('/', async (req, res, next) => {
             cursorData ? 'searchTransit' : 'searchTransitWithTaxi',
         )
         const { tripPatterns, metadata, hasFlexibleTripPattern, queries } =
-            await searchMethod(params, extraHeaders, undefined, searchOptions)
+            await searchMethod(params, extraHeaders)
         stopTrace()
 
         if (!cursorData) {

--- a/src/routes/v1/transit.ts
+++ b/src/routes/v1/transit.ts
@@ -106,6 +106,7 @@ router.post('/', async (req, res, next) => {
 
         useOtp2 = !res.locals.forceOtp1
 
+        //TODO: Hvorfor er denne her og ikke før vi setter searchMethod????
         if (useOtp2) {
             // @ts-ignore searchTransitOtp2 expects a slightly different SearchParams type
             searchMethod = searchTransitOtp2

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,8 @@ export interface Metadata {
 
 export interface TransitTripPatterns {
     tripPatterns: TripPattern[]
-    hasFlexibleTripPattern: boolean
+    // TODO 7/12-21: Only used by OTP1, and no client uses it anymore. Can be removed once OTP1 is removed
+    hasFlexibleTripPattern?: boolean
     queries: GraphqlQuery[]
     metadata?: Metadata
     nextSearchParams?: SearchParams

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,11 +22,6 @@ export interface CursorData {
     params: SearchParams
 }
 
-export interface SearchResults {
-    transitTripPatterns: TransitTripPatterns
-    nonTransitTripPatterns: NonTransitTripPatterns
-}
-
 export interface GraphqlQuery {
     query: string
     variables?: Record<string, unknown>

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export interface CursorData {
 export interface GraphqlQuery {
     query: string
     variables?: Record<string, unknown>
+    comment?: string
 }
 
 export interface Metadata {

--- a/src/utils/osloSTrack1Replacer.ts
+++ b/src/utils/osloSTrack1Replacer.ts
@@ -29,6 +29,8 @@ const replaceQuay1ForOsloSInLeg = (leg: Leg): Leg => {
     }
 }
 
+// This is a hack and it doesn't feel good. We get wrong data from the backend and
+// customers keep getting stuck on the wrong platform (31st of May 2021)
 export function replaceQuay1ForOsloSWithUnknown<T extends TripPattern>(
     tripPattern: T,
 ): T {

--- a/src/utils/tripPattern.ts
+++ b/src/utils/tripPattern.ts
@@ -98,7 +98,11 @@ function isFlexibleTripsInCombination({ legs }: TripPattern): boolean {
 
     const transitLegs = legs.filter(isTransitLeg)
 
-    return transitLegs.length === 1 && isFlexibleLeg(transitLegs[0])
+    return (
+        transitLegs[0] !== undefined &&
+        transitLegs.length === 1 &&
+        isFlexibleLeg(transitLegs[0])
+    )
 }
 
 function isCarAlternative({ legs }: TripPattern): boolean {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
         },
         "sourceMap": true,
         "target": "es2020",
+        "noUncheckedIndexedAccess": true,
         "useUnknownInCatchVariables": false
     },
     "include": ["src/**/*"],


### PR DESCRIPTION
This PR tries to increase readability of the OTP2 transit search code, as well as improve type checking. It introduces more comments than I've ever added to any codebase but it's really hard to convey the meaning in code only. As this is a public repo that should serve as an example of journey planner usage for others than Entur, I think adding a bit of extra comments is a good idea.