### PR TITLE
Return original query when call to journey planner fails, to make it …

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -34,6 +34,26 @@ export class RoutingErrorsError extends Error {
     }
 }
 
+export class GetTripPatternError extends Error {
+    private error: Error
+    private query: GraphqlQuery
+
+    public constructor(error: Error, query: GraphqlQuery) {
+        super()
+        this.message = 'Error while searching for trip patterns'
+        this.error = error
+        this.query = query
+    }
+
+    public getError(): Error {
+        return this.error
+    }
+
+    public getQuery(): GraphqlQuery {
+        return this.query
+    }
+}
+
 export class NotFoundError extends Error {}
 export class InvalidArgumentError extends Error {}
 export class JourneyPlannerError extends Error {}

--- a/src/routes/v1/transit.ts
+++ b/src/routes/v1/transit.ts
@@ -28,7 +28,7 @@ import { filterModesAndSubModes } from '../../utils/modes'
 
 import { ENVIRONMENT } from '../../config'
 import { logTransitAnalytics, logTransitResultStats } from '../../bigquery'
-import { RoutingErrorsError } from '../../errors'
+import { GetTripPatternError, RoutingErrorsError } from '../../errors'
 
 const SEARCH_PARAMS_EXPIRE_IN_SECONDS = 2 * 60 * 60 // two hours
 
@@ -194,6 +194,11 @@ router.post('/', async (req, res, next) => {
                 hasFlexibleTripPattern: false,
                 queries: mapQueries(error.getQueries(), useOtp2),
                 routingErrors: error.getRoutingErrors(),
+            })
+        } else if (error instanceof GetTripPatternError) {
+            return res.status(500).json({
+                tripPatterns: [],
+                queries: mapQueries([error.getQuery()], useOtp2),
             })
         }
         next(error)


### PR DESCRIPTION
...wait for it …easier to debug from the client