### PR TITLE
Fix url in log message

### DIFF
--- a/src/utils/middleware/reqResLoggerMiddleware.ts
+++ b/src/utils/middleware/reqResLoggerMiddleware.ts
@@ -67,7 +67,7 @@ function reqResLoggerMiddleware(
     const startTime = new Date()
     const { method, url } = req
 
-    logger.info(`Request ${req.method} ${req.url}`, {
+    logger.info(`Request ${method} ${url}`, {
         body: reqBodyMapper(req),
         headers: reqHeadersMapper(req),
         method,
@@ -85,7 +85,7 @@ function reqResLoggerMiddleware(
 
         let level = 'info'
         let response = undefined
-        let message = `Response ${res.statusCode} ${req.method} ${req.url}`
+        let message = `Response ${res.statusCode} ${method} ${url}`
 
         if (res.statusCode >= 400) {
             level = 'warning'
@@ -99,7 +99,7 @@ function reqResLoggerMiddleware(
                 }
 
                 if (response?.message) {
-                    message += ` – ${response?.message || ''}`
+                    message += ` - ${response?.message || ''}`
                 }
             }
         }


### PR DESCRIPTION
When using routers, the req.url is altered. The logger middleware therefore has to use the url const that is made in the start of the function.
<img width="225" alt="image" src="https://user-images.githubusercontent.com/4339443/148048288-f8fbf4ea-91c1-425b-8b6e-3bf7c952950a.png">
