### PR TITLE
Car ferry and coach search filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
                 "lz-string": "^1.4.4",
                 "node-fetch": "^2.6.1",
                 "redis": "^3.1.2",
+                "semver": "^7.3.5",
                 "timezone-support": "^2.0.2",
                 "uuid": "^7.0.3",
                 "winston": "^3.3.3"
@@ -34,6 +35,7 @@
                 "@types/node": "^16.11.6",
                 "@types/node-fetch": "^2.5.12",
                 "@types/redis": "^2.8.32",
+                "@types/semver": "^7.3.9",
                 "@types/uuid": "^8.3.1",
                 "@typescript-eslint/eslint-plugin": "^5.3.0",
                 "@typescript-eslint/parser": "^5.3.0",
@@ -1746,6 +1748,12 @@
             "dependencies": {
                 "@types/node": "*"
             }
+        },
+        "node_modules/@types/semver": {
+            "version": "7.3.9",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
+            "integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==",
+            "dev": true
         },
         "node_modules/@types/serve-static": {
             "version": "1.13.10",
@@ -10663,6 +10671,12 @@
             "requires": {
                 "@types/node": "*"
             }
+        },
+        "@types/semver": {
+            "version": "7.3.9",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
+            "integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==",
+            "dev": true
         },
         "@types/serve-static": {
             "version": "1.13.10",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
         "lz-string": "^1.4.4",
         "node-fetch": "^2.6.1",
         "redis": "^3.1.2",
+        "semver": "^7.3.5",
         "timezone-support": "^2.0.2",
         "uuid": "^7.0.3",
         "winston": "^3.3.3"
@@ -53,6 +54,7 @@
         "@types/node": "^16.11.6",
         "@types/node-fetch": "^2.5.12",
         "@types/redis": "^2.8.32",
+        "@types/semver": "^7.3.9",
         "@types/uuid": "^8.3.1",
         "@typescript-eslint/eslint-plugin": "^5.3.0",
         "@typescript-eslint/parser": "^5.3.0",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -39,6 +39,22 @@ export const ALL_RAIL_SUBMODES: TransportSubmode[] = [
     TransportSubmode.REGIONAL_RAIL,
 ]
 
+export const ALL_WATER_SUBMODES: TransportSubmode[] = [
+    TransportSubmode.INTERNATIONAL_CAR_FERRY,
+    TransportSubmode.LOCAL_CAR_FERRY,
+    TransportSubmode.NATIONAL_CAR_FERRY,
+    TransportSubmode.REGIONAL_CAR_FERRY,
+    TransportSubmode.LOCAL_PASSENGER_FERRY,
+    TransportSubmode.INTERNATIONAL_PASSENGER_FERRY,
+]
+
+export const ALL_CAR_FERRY_SUBMODES: TransportSubmode[] = [
+    TransportSubmode.INTERNATIONAL_CAR_FERRY,
+    TransportSubmode.LOCAL_CAR_FERRY,
+    TransportSubmode.NATIONAL_CAR_FERRY,
+    TransportSubmode.REGIONAL_CAR_FERRY,
+]
+
 export const TAXI_LIMITS = {
     DURATION_MAX_HOURS: 4,
     DURATION_MIN_SECONDS: 5 * 60,

--- a/src/logic/otp2/controller.ts
+++ b/src/logic/otp2/controller.ts
@@ -580,7 +580,11 @@ export async function searchTransit(
 
     const getTripPatternsParams = {
         ...searchParams,
-        modes: filterModesAndSubModes(searchFilter),
+        modes: filterModesAndSubModes(
+            searchFilter,
+            extraHeaders['ET-Client-Version'],
+            extraHeaders['ET-Client-Platform'],
+        ),
     }
 
     // initial search date may differ from search date if this is a

--- a/src/logic/otp2/modes.test.ts
+++ b/src/logic/otp2/modes.test.ts
@@ -19,28 +19,6 @@ function getRailFilter(modes: Modes): Mode | undefined {
 }
 
 describe('filterModesAndSubModes', () => {
-    it('should include coach mode if bus mode is present', () => {
-        const modesWithBusWithoutCoach: SearchFilter[] = [
-            SearchFilter.RAIL,
-            SearchFilter.METRO,
-            SearchFilter.BUS,
-            SearchFilter.WATER,
-        ]
-        const modesWithBusAndCoach: any = [SearchFilter.BUS, 'coach']
-        const withoutCoach = filterModesAndSubModes(modesWithBusWithoutCoach)
-        const withCoach = filterModesAndSubModes(modesWithBusAndCoach)
-
-        const coach = withoutCoach.transportModes.some(
-            (m) => m.transportMode === TransportMode.COACH,
-        )
-        expect(coach).toBeTruthy()
-
-        const alreadyCoach = withCoach.transportModes.some(
-            (m) => m.transportMode === TransportMode.COACH,
-        )
-        expect(alreadyCoach).toEqual(true)
-    })
-
     it('should include bus mode and railReplacementBus sub mode if rail mode is present', () => {
         const modesWithRailWithoutBus: SearchFilter[] = [
             SearchFilter.RAIL,

--- a/src/routes/v1/transit.ts
+++ b/src/routes/v1/transit.ts
@@ -44,6 +44,8 @@ function getHeadersFromClient(req: Request): ExtraHeaders {
     return clean({
         'X-Correlation-Id': req.get('X-Correlation-Id'),
         'ET-Client-Name': clientName ? `${clientName}-bff` : 'entur-search',
+        'ET-Client-Version': req.get('ET-Client-Version'),
+        'ET-Client-Platform': req.get('ET-Client-Platform'),
     })
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,11 +59,13 @@ export interface FilteredModesAndSubModes {
 
 export enum SearchFilter {
     BUS = 'bus',
+    COACH = 'coach',
     RAIL = 'rail',
     TRAM = 'tram',
     METRO = 'metro',
     AIR = 'air',
     WATER = 'water',
+    CAR_FERRY = 'car_ferry',
     FLYTOG = 'flytog',
     FLYBUSS = 'flybuss',
 }

--- a/src/utils/modes.test.ts
+++ b/src/utils/modes.test.ts
@@ -28,24 +28,6 @@ function getRailFilter(
 }
 
 describe('filterModesAndSubModes', () => {
-    it('should include coach mode if bus mode is present', () => {
-        const modesWithBusWithoutCoach: SearchFilter[] = [
-            SearchFilter.RAIL,
-            SearchFilter.METRO,
-            SearchFilter.BUS,
-            SearchFilter.WATER,
-        ]
-        const modesWithBusAndCoach: any = ['foot', SearchFilter.BUS, 'coach']
-        const { filteredModes: withoutCoach } = filterModesAndSubModes(
-            modesWithBusWithoutCoach,
-        )
-        const { filteredModes: withCoach } =
-            filterModesAndSubModes(modesWithBusAndCoach)
-
-        expect(withoutCoach).toContain(LegMode.COACH)
-        expect(withCoach).toContain(LegMode.COACH)
-    })
-
     it('should add foot if not included', () => {
         const modesWithoutFoot: any = [
             SearchFilter.BUS,


### PR DESCRIPTION
Added possibility to filter tripPatterns for coach (express bus) and car ferries.
Two new SearchFilter values: COACH and CAR_FERRY

This will only affect version > 8.10.1 so that tripPatterns with Coach will not disappear from older versions, but this condition will be removed 2 weeks after the release of 8.11.1.