### PR TITLE
Generate types from GraphQL

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@
 api
 dist
 node_modules
+src/generated/graphql.ts

--- a/codegen.yml
+++ b/codegen.yml
@@ -1,0 +1,26 @@
+overwrite: true
+schema: 'https://api.staging.entur.io/journey-planner/v3/graphql'
+documents: 'src/logic/otp2/query.ts'
+hooks:
+    afterAllFileWrite:
+        - prettier --write
+generates:
+    src/generated/graphql.ts:
+        plugins:
+            - 'typescript'
+            - 'typescript-operations'
+        config:
+            strictScalars: true
+            avoidOptionals:
+                field: true
+                inputValue: true
+                object: false
+                defaultValue: false
+            scalars:
+                Coordinates: 'Array<[lat: number, lon: number]>'
+                Date: string
+                DateTime: string
+                DoubleFunction: string
+                LocalTime: string
+                Long: number
+                Time: string

--- a/codegen.yml
+++ b/codegen.yml
@@ -1,5 +1,5 @@
 overwrite: true
-schema: 'https://api.staging.entur.io/journey-planner/v3/graphql'
+schema: 'https://api.entur.io/journey-planner/v3/graphql'
 documents: 'src/logic/otp2/query.ts'
 hooks:
     afterAllFileWrite:

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
                 "date-fns": "^2.28.0",
                 "express": "^4.17.3",
                 "express-jwt": "^6.1.0",
+                "graphql-request": "^3.7.0",
                 "jwks-rsa": "^2.0.5",
                 "lz-string": "^1.4.4",
                 "node-fetch": "^2.6.7",
@@ -29,9 +30,14 @@
             },
             "devDependencies": {
                 "@babel/code-frame": "^7.16.7",
+                "@graphql-codegen/cli": "2.4.0",
+                "@graphql-codegen/typescript": "2.4.2",
+                "@graphql-codegen/typescript-graphql-files-modules": "2.1.1",
+                "@graphql-codegen/typescript-operations": "2.2.2",
                 "@types/babel__code-frame": "^7.0.3",
                 "@types/cors": "^2.8.12",
                 "@types/express": "^4.17.13",
+                "@types/graphql": "^14.5.0",
                 "@types/jest": "^27.4.0",
                 "@types/lz-string": "^1.3.34",
                 "@types/node": "16.11.6",
@@ -45,6 +51,7 @@
                 "eslint": "^8.9.0",
                 "eslint-plugin-fp": "^2.3.0",
                 "eslint-plugin-prettier": "^4.0.0",
+                "graphql": "^15.8.0",
                 "jest": "^27.5.1",
                 "nodemon": "^2.0.15",
                 "prettier": "2.5.1",
@@ -70,9 +77,9 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.0.tgz",
-            "integrity": "sha512-DGjt2QZse5SGd9nfOSqO4WLJ8NN/oHkijbXbPrxuoJO3oIPJL3TciZs9FX+cOHNiY9E9l0opL8g7BmLe3T+9ew==",
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.0.tgz",
+            "integrity": "sha512-392byTlpGWXMv4FbyWw3sAZ/FrW/DrwqLGXpy0mbyNe9Taqv1mg9yON5/o0cnr8XYCkFTZbC1eV+c+LAROgrng==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
@@ -127,12 +134,12 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
-            "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
+            "version": "7.17.3",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.3.tgz",
+            "integrity": "sha512-+R6Dctil/MgUsZsZAkYgK+ADNSZzJRRy0TvY65T71z/CR854xHQ1EweBYXdfT+HNeN7w0cSJJEzgxZMv40pxsg==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.16.0",
+                "@babel/types": "^7.17.0",
                 "jsesc": "^2.5.1",
                 "source-map": "^0.5.0"
             },
@@ -149,15 +156,27 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.0.tgz",
-            "integrity": "sha512-S7iaOT1SYlqK0sQaCi21RX4+13hmdmnxIEAnQUB/eh7GeAnRjOUgTYpLkUOiRXzD+yog1JxP0qyAQZ7ZxVxLVg==",
+        "node_modules/@babel/helper-annotate-as-pure": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz",
+            "integrity": "sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==",
             "dev": true,
             "dependencies": {
-                "@babel/compat-data": "^7.16.0",
-                "@babel/helper-validator-option": "^7.14.5",
-                "browserslist": "^4.16.6",
+                "@babel/types": "^7.16.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-compilation-targets": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.7.tgz",
+            "integrity": "sha512-mGojBwIWcwGD6rfqgRXVlVYmPAv7eOpIemUG3dGnDdCY4Pae70ROij3XmfrH6Fa1h1aiDylpglbZyktfzyo/hA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/compat-data": "^7.16.4",
+                "@babel/helper-validator-option": "^7.16.7",
+                "browserslist": "^4.17.5",
                 "semver": "^6.3.0"
             },
             "engines": {
@@ -176,94 +195,127 @@
                 "semver": "bin/semver.js"
             }
         },
-        "node_modules/@babel/helper-function-name": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
-            "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
+        "node_modules/@babel/helper-create-class-features-plugin": {
+            "version": "7.17.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.17.6.tgz",
+            "integrity": "sha512-SogLLSxXm2OkBbSsHZMM4tUi8fUzjs63AT/d0YQIzr6GSd8Hxsbk2KYDX0k0DweAzGMj/YWeiCsorIdtdcW8Eg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-get-function-arity": "^7.16.0",
-                "@babel/template": "^7.16.0",
-                "@babel/types": "^7.16.0"
+                "@babel/helper-annotate-as-pure": "^7.16.7",
+                "@babel/helper-environment-visitor": "^7.16.7",
+                "@babel/helper-function-name": "^7.16.7",
+                "@babel/helper-member-expression-to-functions": "^7.16.7",
+                "@babel/helper-optimise-call-expression": "^7.16.7",
+                "@babel/helper-replace-supers": "^7.16.7",
+                "@babel/helper-split-export-declaration": "^7.16.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/helper-environment-visitor": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz",
+            "integrity": "sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==",
+            "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.16.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-function-name": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
+            "integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-get-function-arity": "^7.16.7",
+                "@babel/template": "^7.16.7",
+                "@babel/types": "^7.16.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-get-function-arity": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
-            "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
+            "integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.16.0"
+                "@babel/types": "^7.16.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-hoist-variables": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
-            "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
+            "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.16.0"
+                "@babel/types": "^7.16.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-member-expression-to-functions": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.0.tgz",
-            "integrity": "sha512-bsjlBFPuWT6IWhl28EdrQ+gTvSvj5tqVP5Xeftp07SEuz5pLnsXZuDkDD3Rfcxy0IsHmbZ+7B2/9SHzxO0T+sQ==",
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.7.tgz",
+            "integrity": "sha512-VtJ/65tYiU/6AbMTDwyoXGPKHgTsfRarivm+YbB5uAzKUyuPjgZSgAFeG87FCigc7KNHu2Pegh1XIT3lXjvz3Q==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.16.0"
+                "@babel/types": "^7.16.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz",
-            "integrity": "sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==",
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
+            "integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.16.0"
+                "@babel/types": "^7.16.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.0.tgz",
-            "integrity": "sha512-My4cr9ATcaBbmaEa8M0dZNA74cfI6gitvUAskgDtAFmAqyFKDSHQo5YstxPbN+lzHl2D9l/YOEFqb2mtUh4gfA==",
+            "version": "7.17.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.6.tgz",
+            "integrity": "sha512-2ULmRdqoOMpdvkbT8jONrZML/XALfzxlb052bldftkicAUy8AxSCkD5trDPQcwHNmolcl7wP6ehNqMlyUw6AaA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-module-imports": "^7.16.0",
-                "@babel/helper-replace-supers": "^7.16.0",
-                "@babel/helper-simple-access": "^7.16.0",
-                "@babel/helper-split-export-declaration": "^7.16.0",
-                "@babel/helper-validator-identifier": "^7.15.7",
-                "@babel/template": "^7.16.0",
-                "@babel/traverse": "^7.16.0",
-                "@babel/types": "^7.16.0"
+                "@babel/helper-environment-visitor": "^7.16.7",
+                "@babel/helper-module-imports": "^7.16.7",
+                "@babel/helper-simple-access": "^7.16.7",
+                "@babel/helper-split-export-declaration": "^7.16.7",
+                "@babel/helper-validator-identifier": "^7.16.7",
+                "@babel/template": "^7.16.7",
+                "@babel/traverse": "^7.17.3",
+                "@babel/types": "^7.17.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-optimise-call-expression": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.0.tgz",
-            "integrity": "sha512-SuI467Gi2V8fkofm2JPnZzB/SUuXoJA5zXe/xzyPP2M04686RzFKFHPK6HDVN6JvWBIEW8tt9hPR7fXdn2Lgpw==",
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.7.tgz",
+            "integrity": "sha512-EtgBhg7rd/JcnpZFXpBy0ze1YRfdm7BnBX4uKMBd3ixa3RGAE002JZB66FJyNH7g0F38U05pXmA5P8cBh7z+1w==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.16.0"
+                "@babel/types": "^7.16.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -279,24 +331,37 @@
             }
         },
         "node_modules/@babel/helper-replace-supers": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.16.0.tgz",
-            "integrity": "sha512-TQxuQfSCdoha7cpRNJvfaYxxxzmbxXw/+6cS7V02eeDYyhxderSoMVALvwupA54/pZcOTtVeJ0xccp1nGWladA==",
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.16.7.tgz",
+            "integrity": "sha512-y9vsWilTNaVnVh6xiJfABzsNpgDPKev9HnAgz6Gb1p6UUwf9NepdlsV7VXGCftJM+jqD5f7JIEubcpLjZj5dBw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-member-expression-to-functions": "^7.16.0",
-                "@babel/helper-optimise-call-expression": "^7.16.0",
-                "@babel/traverse": "^7.16.0",
-                "@babel/types": "^7.16.0"
+                "@babel/helper-environment-visitor": "^7.16.7",
+                "@babel/helper-member-expression-to-functions": "^7.16.7",
+                "@babel/helper-optimise-call-expression": "^7.16.7",
+                "@babel/traverse": "^7.16.7",
+                "@babel/types": "^7.16.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-simple-access": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.7.tgz",
+            "integrity": "sha512-ZIzHVyoeLMvXMN/vok/a4LWRy8G2v205mNP0XOuf9XRLyX5/u9CnVulUtDgUTama3lT+bf/UqucuZjqiGuTS1g==",
+            "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.16.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
             "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.0.tgz",
-            "integrity": "sha512-o1rjBT/gppAqKsYfUdfHq5Rk03lMQrkPHG1OWzHWpLgVXRH4HnMM9Et9CVdIqwkCQlobnGHEJMsgWP/jE1zUiw==",
+            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.16.0.tgz",
+            "integrity": "sha512-+il1gTy0oHwUsBQZyJvukbB4vPMdcYBrFHa0Uc4AizLxbq6BOYC51Rv4tWocX9BLBDLZ4kc6qUFpQ6HRgL+3zw==",
             "dev": true,
             "dependencies": {
                 "@babel/types": "^7.16.0"
@@ -306,12 +371,12 @@
             }
         },
         "node_modules/@babel/helper-split-export-declaration": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
-            "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
+            "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.16.0"
+                "@babel/types": "^7.16.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -327,9 +392,9 @@
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.14.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
-            "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
+            "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
@@ -435,15 +500,50 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.16.2",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.2.tgz",
-            "integrity": "sha512-RUVpT0G2h6rOZwqLDTrKk7ksNv7YpAilTnYe1/Q+eDjxEceRMKVWbCsX7t8h6C1qCFi/1Y8WZjcEPBAFG27GPw==",
+            "version": "7.17.3",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.3.tgz",
+            "integrity": "sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA==",
             "dev": true,
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@babel/plugin-proposal-class-properties": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.16.7.tgz",
+            "integrity": "sha512-IobU0Xme31ewjYOShSIqd/ZGM/r/cuOz2z0MDbNrhF5FW+ZVgi0f2lyeoj9KFPDOAqsYxmLWZte1WOwlvY9aww==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-create-class-features-plugin": "^7.16.7",
+                "@babel/helper-plugin-utils": "^7.16.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-proposal-object-rest-spread": {
+            "version": "7.17.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.17.3.tgz",
+            "integrity": "sha512-yuL5iQA/TbZn+RGAfxQXfi7CNLmKi1f8zInn4IgobuCWcAb7i+zj4TYzQ9l8cEzVyJ89PDGuqxK1xZpUDISesw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/compat-data": "^7.17.0",
+                "@babel/helper-compilation-targets": "^7.16.7",
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+                "@babel/plugin-transform-parameters": "^7.16.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
             }
         },
         "node_modules/@babel/plugin-syntax-async-generators": {
@@ -482,6 +582,21 @@
                 "@babel/core": "^7.0.0-0"
             }
         },
+        "node_modules/@babel/plugin-syntax-flow": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.16.7.tgz",
+            "integrity": "sha512-UDo3YGQO0jH6ytzVwgSLv9i/CzMcUjbKenL67dTrAZPPv6GFAtDhe6jqnvmoKzC/7htNTohhos+onPtDMqJwaQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
         "node_modules/@babel/plugin-syntax-import-meta": {
             "version": "7.10.4",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
@@ -501,6 +616,21 @@
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-jsx": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.16.7.tgz",
+            "integrity": "sha512-Esxmk7YjA8QysKeT3VhTXvF6y77f/a91SIs4pWb4H2eWGQkCKFgQaG6hdoEVZtGsrAcb2K5BW66XsOErD4WU3Q==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0-0"
@@ -608,6 +738,334 @@
                 "@babel/core": "^7.0.0-0"
             }
         },
+        "node_modules/@babel/plugin-transform-arrow-functions": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.16.7.tgz",
+            "integrity": "sha512-9ffkFFMbvzTvv+7dTp/66xvZAWASuPD5Tl9LK3Z9vhOmANo6j94rik+5YMBt4CwHVMWLWpMsriIc2zsa3WW3xQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-block-scoped-functions": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.16.7.tgz",
+            "integrity": "sha512-JUuzlzmF40Z9cXyytcbZEZKckgrQzChbQJw/5PuEHYeqzCsvebDx0K0jWnIIVcmmDOAVctCgnYs0pMcrYj2zJg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-block-scoping": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.16.7.tgz",
+            "integrity": "sha512-ObZev2nxVAYA4bhyusELdo9hb3H+A56bxH3FZMbEImZFiEDYVHXQSJ1hQKFlDnlt8G9bBrCZ5ZpURZUrV4G5qQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-classes": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.16.7.tgz",
+            "integrity": "sha512-WY7og38SFAGYRe64BrjKf8OrE6ulEHtr5jEYaZMwox9KebgqPi67Zqz8K53EKk1fFEJgm96r32rkKZ3qA2nCWQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-annotate-as-pure": "^7.16.7",
+                "@babel/helper-environment-visitor": "^7.16.7",
+                "@babel/helper-function-name": "^7.16.7",
+                "@babel/helper-optimise-call-expression": "^7.16.7",
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "@babel/helper-replace-supers": "^7.16.7",
+                "@babel/helper-split-export-declaration": "^7.16.7",
+                "globals": "^11.1.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-classes/node_modules/globals": {
+            "version": "11.12.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@babel/plugin-transform-computed-properties": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.16.7.tgz",
+            "integrity": "sha512-gN72G9bcmenVILj//sv1zLNaPyYcOzUho2lIJBMh/iakJ9ygCo/hEF9cpGb61SCMEDxbbyBoVQxrt+bWKu5KGw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-destructuring": {
+            "version": "7.17.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.17.3.tgz",
+            "integrity": "sha512-dDFzegDYKlPqa72xIlbmSkly5MluLoaC1JswABGktyt6NTXSBcUuse/kWE/wvKFWJHPETpi158qJZFS3JmykJg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-flow-strip-types": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.16.7.tgz",
+            "integrity": "sha512-mzmCq3cNsDpZZu9FADYYyfZJIOrSONmHcop2XEKPdBNMa4PDC4eEvcOvzZaCNcjKu72v0XQlA5y1g58aLRXdYg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "@babel/plugin-syntax-flow": "^7.16.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-for-of": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.16.7.tgz",
+            "integrity": "sha512-/QZm9W92Ptpw7sjI9Nx1mbcsWz33+l8kuMIQnDwgQBG5s3fAfQvkRjQ7NqXhtNcKOnPkdICmUHyCaWW06HCsqg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-function-name": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.16.7.tgz",
+            "integrity": "sha512-SU/C68YVwTRxqWj5kgsbKINakGag0KTgq9f2iZEXdStoAbOzLHEBRYzImmA6yFo8YZhJVflvXmIHUO7GWHmxxA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-compilation-targets": "^7.16.7",
+                "@babel/helper-function-name": "^7.16.7",
+                "@babel/helper-plugin-utils": "^7.16.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-literals": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.16.7.tgz",
+            "integrity": "sha512-6tH8RTpTWI0s2sV6uq3e/C9wPo4PTqqZps4uF0kzQ9/xPLFQtipynvmT1g/dOfEJ+0EQsHhkQ/zyRId8J2b8zQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-member-expression-literals": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.16.7.tgz",
+            "integrity": "sha512-mBruRMbktKQwbxaJof32LT9KLy2f3gH+27a5XSuXo6h7R3vqltl0PgZ80C8ZMKw98Bf8bqt6BEVi3svOh2PzMw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-modules-commonjs": {
+            "version": "7.16.8",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.16.8.tgz",
+            "integrity": "sha512-oflKPvsLT2+uKQopesJt3ApiaIS2HW+hzHFcwRNtyDGieAeC/dIHZX8buJQ2J2X1rxGPy4eRcUijm3qcSPjYcA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-module-transforms": "^7.16.7",
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "@babel/helper-simple-access": "^7.16.7",
+                "babel-plugin-dynamic-import-node": "^2.3.3"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-object-super": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.16.7.tgz",
+            "integrity": "sha512-14J1feiQVWaGvRxj2WjyMuXS2jsBkgB3MdSN5HuC2G5nRspa5RK9COcs82Pwy5BuGcjb+fYaUj94mYcOj7rCvw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "@babel/helper-replace-supers": "^7.16.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-parameters": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.16.7.tgz",
+            "integrity": "sha512-AT3MufQ7zZEhU2hwOA11axBnExW0Lszu4RL/tAlUJBuNoRak+wehQW8h6KcXOcgjY42fHtDxswuMhMjFEuv/aw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-property-literals": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.16.7.tgz",
+            "integrity": "sha512-z4FGr9NMGdoIl1RqavCqGG+ZuYjfZ/hkCIeuH6Do7tXmSm0ls11nYVSJqFEUOSJbDab5wC6lRE/w6YjVcr6Hqw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-react-display-name": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.16.7.tgz",
+            "integrity": "sha512-qgIg8BcZgd0G/Cz916D5+9kqX0c7nPZyXaP8R2tLNN5tkyIZdG5fEwBrxwplzSnjC1jvQmyMNVwUCZPcbGY7Pg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-react-jsx": {
+            "version": "7.17.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.17.3.tgz",
+            "integrity": "sha512-9tjBm4O07f7mzKSIlEmPdiE6ub7kfIe6Cd+w+oQebpATfTQMAgW+YOuWxogbKVTulA+MEO7byMeIUtQ1z+z+ZQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-annotate-as-pure": "^7.16.7",
+                "@babel/helper-module-imports": "^7.16.7",
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "@babel/plugin-syntax-jsx": "^7.16.7",
+                "@babel/types": "^7.17.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-shorthand-properties": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.16.7.tgz",
+            "integrity": "sha512-hah2+FEnoRoATdIb05IOXf+4GzXYTq75TVhIn1PewihbpyrNWUt2JbudKQOETWw6QpLe+AIUpJ5MVLYTQbeeUg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-spread": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.16.7.tgz",
+            "integrity": "sha512-+pjJpgAngb53L0iaA5gU/1MLXJIfXcYepLgXB3esVRf4fqmj8f2cxM3/FKaHsZms08hFQJkFccEWuIpm429TXg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-template-literals": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.16.7.tgz",
+            "integrity": "sha512-VwbkDDUeenlIjmfNeDX/V0aWrQH2QiVyJtwymVQSzItFDTpxfyJh3EVaQiS0rIN/CqbLGr0VcGmuwyTdZtdIsA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
         "node_modules/@babel/polyfill": {
             "version": "7.12.1",
             "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
@@ -618,33 +1076,46 @@
                 "regenerator-runtime": "^0.13.4"
             }
         },
-        "node_modules/@babel/template": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
-            "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
+        "node_modules/@babel/runtime": {
+            "version": "7.17.2",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
+            "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.16.0",
-                "@babel/parser": "^7.16.0",
-                "@babel/types": "^7.16.0"
+                "regenerator-runtime": "^0.13.4"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/template": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
+            "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
+            "dev": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.16.7",
+                "@babel/parser": "^7.16.7",
+                "@babel/types": "^7.16.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.0.tgz",
-            "integrity": "sha512-qQ84jIs1aRQxaGaxSysII9TuDaguZ5yVrEuC0BN2vcPlalwfLovVmCjbFDPECPXcYM/wLvNFfp8uDOliLxIoUQ==",
+            "version": "7.17.3",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
+            "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.16.0",
-                "@babel/generator": "^7.16.0",
-                "@babel/helper-function-name": "^7.16.0",
-                "@babel/helper-hoist-variables": "^7.16.0",
-                "@babel/helper-split-export-declaration": "^7.16.0",
-                "@babel/parser": "^7.16.0",
-                "@babel/types": "^7.16.0",
+                "@babel/code-frame": "^7.16.7",
+                "@babel/generator": "^7.17.3",
+                "@babel/helper-environment-visitor": "^7.16.7",
+                "@babel/helper-function-name": "^7.16.7",
+                "@babel/helper-hoist-variables": "^7.16.7",
+                "@babel/helper-split-export-declaration": "^7.16.7",
+                "@babel/parser": "^7.17.3",
+                "@babel/types": "^7.17.0",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
             },
@@ -662,12 +1133,12 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
-            "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+            "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.15.7",
+                "@babel/helper-validator-identifier": "^7.16.7",
                 "to-fast-properties": "^2.0.0"
             },
             "engines": {
@@ -718,6 +1189,56 @@
                 "enabled": "2.0.x",
                 "kuler": "^2.0.0"
             }
+        },
+        "node_modules/@endemolshinegroup/cosmiconfig-typescript-loader": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@endemolshinegroup/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-3.0.2.tgz",
+            "integrity": "sha512-QRVtqJuS1mcT56oHpVegkKBlgtWjXw/gHNWO3eL9oyB5Sc7HBoc2OLG/nYpVfT/Jejvo3NUrD0Udk7XgoyDKkA==",
+            "dev": true,
+            "dependencies": {
+                "lodash.get": "^4",
+                "make-error": "^1",
+                "ts-node": "^9",
+                "tslib": "^2"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "cosmiconfig": ">=6"
+            }
+        },
+        "node_modules/@endemolshinegroup/cosmiconfig-typescript-loader/node_modules/ts-node": {
+            "version": "9.1.1",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+            "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+            "dev": true,
+            "dependencies": {
+                "arg": "^4.1.0",
+                "create-require": "^1.1.0",
+                "diff": "^4.0.1",
+                "make-error": "^1.1.1",
+                "source-map-support": "^0.5.17",
+                "yn": "3.1.1"
+            },
+            "bin": {
+                "ts-node": "dist/bin.js",
+                "ts-node-script": "dist/bin-script.js",
+                "ts-node-transpile-only": "dist/bin-transpile.js",
+                "ts-script": "dist/bin-script-deprecated.js"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "typescript": ">=2.7"
+            }
+        },
+        "node_modules/@endemolshinegroup/cosmiconfig-typescript-loader/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
         },
         "node_modules/@entur/sdk": {
             "version": "4.4.0",
@@ -903,6 +1424,785 @@
                 "node": ">=10"
             }
         },
+        "node_modules/@graphql-codegen/cli": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@graphql-codegen/cli/-/cli-2.4.0.tgz",
+            "integrity": "sha512-4iiHH2AxBE17lX5cFdFg6+kh7I6uKQLYG0IZRalRbW/grKL7kuVp/RDUjmVB2GNJTJEhjxYLMJFJZocUmAUBlw==",
+            "dev": true,
+            "dependencies": {
+                "@graphql-codegen/core": "2.4.0",
+                "@graphql-codegen/plugin-helpers": "^2.3.2",
+                "@graphql-tools/apollo-engine-loader": "^7.0.5",
+                "@graphql-tools/code-file-loader": "^7.0.6",
+                "@graphql-tools/git-loader": "^7.0.5",
+                "@graphql-tools/github-loader": "^7.0.5",
+                "@graphql-tools/graphql-file-loader": "^7.0.5",
+                "@graphql-tools/json-file-loader": "^7.1.2",
+                "@graphql-tools/load": "^7.3.0",
+                "@graphql-tools/prisma-loader": "^7.0.6",
+                "@graphql-tools/url-loader": "^7.0.11",
+                "@graphql-tools/utils": "^8.1.1",
+                "ansi-escapes": "^4.3.1",
+                "chalk": "^4.1.0",
+                "change-case-all": "1.0.14",
+                "chokidar": "^3.5.2",
+                "common-tags": "^1.8.0",
+                "cosmiconfig": "^7.0.0",
+                "debounce": "^1.2.0",
+                "dependency-graph": "^0.11.0",
+                "detect-indent": "^6.0.0",
+                "glob": "^7.1.6",
+                "globby": "^11.0.4",
+                "graphql-config": "^4.1.0",
+                "inquirer": "^8.0.0",
+                "is-glob": "^4.0.1",
+                "json-to-pretty-yaml": "^1.2.2",
+                "latest-version": "5.1.0",
+                "listr": "^0.14.3",
+                "listr-update-renderer": "^0.5.0",
+                "log-symbols": "^4.0.0",
+                "minimatch": "^3.0.4",
+                "mkdirp": "^1.0.4",
+                "string-env-interpolation": "^1.0.1",
+                "ts-log": "^2.2.3",
+                "tslib": "~2.3.0",
+                "valid-url": "^1.0.9",
+                "wrap-ansi": "^7.0.0",
+                "yaml": "^1.10.0",
+                "yargs": "^17.0.0"
+            },
+            "bin": {
+                "gql-gen": "bin.js",
+                "graphql-code-generator": "bin.js",
+                "graphql-codegen": "bin.js"
+            },
+            "peerDependencies": {
+                "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+            }
+        },
+        "node_modules/@graphql-codegen/cli/node_modules/mkdirp": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+            "dev": true,
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@graphql-codegen/cli/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
+        "node_modules/@graphql-codegen/cli/node_modules/yargs": {
+            "version": "17.3.1",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+            "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
+            "dev": true,
+            "dependencies": {
+                "cliui": "^7.0.2",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@graphql-codegen/cli/node_modules/yargs-parser": {
+            "version": "21.0.0",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
+            "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@graphql-codegen/core": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@graphql-codegen/core/-/core-2.4.0.tgz",
+            "integrity": "sha512-5RiYE1+07jayp/3w/bkyaCXtfKNeKmRabpPP4aRi369WeH2cH37l2K8NbhkIU+zhpnhoqMID61TO56x2fKldZQ==",
+            "dev": true,
+            "dependencies": {
+                "@graphql-codegen/plugin-helpers": "^2.3.2",
+                "@graphql-tools/schema": "^8.1.2",
+                "@graphql-tools/utils": "^8.1.1",
+                "tslib": "~2.3.0"
+            },
+            "peerDependencies": {
+                "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+            }
+        },
+        "node_modules/@graphql-codegen/core/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
+        "node_modules/@graphql-codegen/plugin-helpers": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-2.4.1.tgz",
+            "integrity": "sha512-OPMma7aUnES3Dh+M0BfiNBnJLmYuH60EnbULAhufxFDn/Y2OA0Ht/LQok9beX6VN4ASZEMCOAGItJezGJr5DJw==",
+            "dev": true,
+            "dependencies": {
+                "@graphql-tools/utils": "^8.5.2",
+                "change-case-all": "1.0.14",
+                "common-tags": "1.8.2",
+                "import-from": "4.0.0",
+                "lodash": "~4.17.0",
+                "tslib": "~2.3.0"
+            },
+            "peerDependencies": {
+                "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+            }
+        },
+        "node_modules/@graphql-codegen/plugin-helpers/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
+        "node_modules/@graphql-codegen/schema-ast": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@graphql-codegen/schema-ast/-/schema-ast-2.4.1.tgz",
+            "integrity": "sha512-bIWlKk/ShoVJfghA4Rt1OWnd34/dQmZM/vAe6fu6QKyOh44aAdqPtYQ2dbTyFXoknmu504etKJGEDllYNUJRfg==",
+            "dev": true,
+            "dependencies": {
+                "@graphql-codegen/plugin-helpers": "^2.3.2",
+                "@graphql-tools/utils": "^8.1.1",
+                "tslib": "~2.3.0"
+            },
+            "peerDependencies": {
+                "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+            }
+        },
+        "node_modules/@graphql-codegen/schema-ast/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
+        "node_modules/@graphql-codegen/typescript": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-2.4.2.tgz",
+            "integrity": "sha512-8ajWidiFqF1KNAywtb/692SjwTyjzrDHo1sf2Q7Z+rh9qDEIrh83VHB8naT/1CefOvxj3MS6GbcsvJMizaE/AQ==",
+            "dev": true,
+            "dependencies": {
+                "@graphql-codegen/plugin-helpers": "^2.3.2",
+                "@graphql-codegen/schema-ast": "^2.4.1",
+                "@graphql-codegen/visitor-plugin-common": "2.5.2",
+                "auto-bind": "~4.0.0",
+                "tslib": "~2.3.0"
+            },
+            "peerDependencies": {
+                "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+            }
+        },
+        "node_modules/@graphql-codegen/typescript-graphql-files-modules": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-graphql-files-modules/-/typescript-graphql-files-modules-2.1.1.tgz",
+            "integrity": "sha512-MmLHjLoS5zrzDOtu9B4XjSs/OJr267dhRX9Wuz8jIB0azZBhJWVDw3p8O/0/Y+IbIXAbhSPlPVyaU4eWsJOgtQ==",
+            "dev": true,
+            "dependencies": {
+                "@graphql-codegen/plugin-helpers": "^2.3.2",
+                "tslib": "~2.3.0"
+            },
+            "peerDependencies": {
+                "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+            }
+        },
+        "node_modules/@graphql-codegen/typescript-graphql-files-modules/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
+        "node_modules/@graphql-codegen/typescript-operations": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-operations/-/typescript-operations-2.2.2.tgz",
+            "integrity": "sha512-J50AuTA37RYv67hP2oHbfr3iGxexTCoadQsbr5pEUGucrIupCA0hLEJH2W+9/h6YNh0UlZT3kRTJp81ARoAjOA==",
+            "dev": true,
+            "dependencies": {
+                "@graphql-codegen/plugin-helpers": "^2.3.2",
+                "@graphql-codegen/typescript": "^2.4.2",
+                "@graphql-codegen/visitor-plugin-common": "2.5.2",
+                "auto-bind": "~4.0.0",
+                "tslib": "~2.3.0"
+            },
+            "peerDependencies": {
+                "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+            }
+        },
+        "node_modules/@graphql-codegen/typescript-operations/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
+        "node_modules/@graphql-codegen/typescript/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
+        "node_modules/@graphql-codegen/visitor-plugin-common": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.5.2.tgz",
+            "integrity": "sha512-qDMraPmumG+vEGAz42/asRkdgIRmQWH5HTc320UX+I6CY6eE/Ey85cgzoqeQGLV8gu4sj3UkNx/3/r79eX4u+Q==",
+            "dev": true,
+            "dependencies": {
+                "@graphql-codegen/plugin-helpers": "^2.3.2",
+                "@graphql-tools/optimize": "^1.0.1",
+                "@graphql-tools/relay-operation-optimizer": "^6.3.7",
+                "@graphql-tools/utils": "^8.3.0",
+                "auto-bind": "~4.0.0",
+                "change-case-all": "1.0.14",
+                "dependency-graph": "^0.11.0",
+                "graphql-tag": "^2.11.0",
+                "parse-filepath": "^1.0.2",
+                "tslib": "~2.3.0"
+            },
+            "peerDependencies": {
+                "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+            }
+        },
+        "node_modules/@graphql-codegen/visitor-plugin-common/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
+        "node_modules/@graphql-tools/apollo-engine-loader": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/apollo-engine-loader/-/apollo-engine-loader-7.2.3.tgz",
+            "integrity": "sha512-c1AVwAoKf/dSQw6yn/OfwobybplDuAJWLvJS7K7Bm4BiFv0/YXiizPTMsYvxlJYg3uGvmA7fsoeicrzBdlwOpA==",
+            "dev": true,
+            "dependencies": {
+                "@graphql-tools/utils": "^8.6.2",
+                "cross-undici-fetch": "^0.1.19",
+                "sync-fetch": "0.3.1",
+                "tslib": "~2.3.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/apollo-engine-loader/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
+        "node_modules/@graphql-tools/batch-execute": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.3.2.tgz",
+            "integrity": "sha512-ICWqM+MvEkIPHm18Q0cmkvm134zeQMomBKmTRxyxMNhL/ouz6Nqld52/brSlaHnzA3fczupeRJzZ0YatruGBcQ==",
+            "dev": true,
+            "dependencies": {
+                "@graphql-tools/utils": "^8.6.2",
+                "dataloader": "2.0.0",
+                "tslib": "~2.3.0",
+                "value-or-promise": "1.0.11"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/batch-execute/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
+        "node_modules/@graphql-tools/code-file-loader": {
+            "version": "7.2.4",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-7.2.4.tgz",
+            "integrity": "sha512-KjIxYKDIbrtRGzeboYC98OnRnCvDVDC3E+suH48J4/KxweSjrG+ZpD++T/A11FdIcFb1Y5OceCw+OwjHI5OoyQ==",
+            "dev": true,
+            "dependencies": {
+                "@graphql-tools/graphql-tag-pluck": "^7.1.6",
+                "@graphql-tools/utils": "^8.6.2",
+                "globby": "^11.0.3",
+                "tslib": "~2.3.0",
+                "unixify": "^1.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/code-file-loader/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
+        "node_modules/@graphql-tools/delegate": {
+            "version": "8.5.1",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.5.1.tgz",
+            "integrity": "sha512-/YPmVxitt57F8sH50pnfXASzOOjEfaUDkX48eF5q6f16+JBncej2zeu+Zm2c68q8MbIxhPlEGfpd0QZeqTvAxw==",
+            "dev": true,
+            "dependencies": {
+                "@graphql-tools/batch-execute": "^8.3.2",
+                "@graphql-tools/schema": "^8.3.2",
+                "@graphql-tools/utils": "^8.6.2",
+                "dataloader": "2.0.0",
+                "graphql-executor": "0.0.18",
+                "tslib": "~2.3.0",
+                "value-or-promise": "1.0.11"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/delegate/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
+        "node_modules/@graphql-tools/git-loader": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/git-loader/-/git-loader-7.1.3.tgz",
+            "integrity": "sha512-Ya0jRizD6F1hbajk2rwfqJKAp6dQRvzW1gzkOQmlNcQOTtTjWITsFtzk7fS02gZRWkfFBenlTBguGufh91I6bg==",
+            "dev": true,
+            "dependencies": {
+                "@graphql-tools/graphql-tag-pluck": "^7.1.6",
+                "@graphql-tools/utils": "^8.6.2",
+                "is-glob": "4.0.3",
+                "micromatch": "^4.0.4",
+                "tslib": "~2.3.0",
+                "unixify": "^1.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/git-loader/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
+        "node_modules/@graphql-tools/github-loader": {
+            "version": "7.2.4",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/github-loader/-/github-loader-7.2.4.tgz",
+            "integrity": "sha512-QuSN2GWgm/h3lp7o5zpi8TzHnzom4b/f5Zq4Hvprn1OsGaOviHLXQUx6AaWa07cmFvPL0se79R0sEkMZlXlpQQ==",
+            "dev": true,
+            "dependencies": {
+                "@graphql-tools/graphql-tag-pluck": "^7.1.6",
+                "@graphql-tools/utils": "^8.6.2",
+                "cross-undici-fetch": "^0.1.19",
+                "sync-fetch": "0.3.1",
+                "tslib": "~2.3.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/github-loader/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
+        "node_modules/@graphql-tools/graphql-file-loader": {
+            "version": "7.3.4",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.3.4.tgz",
+            "integrity": "sha512-Q0/YtDq0APR6syRclsQMNguWKRlchd8nFTOpLhfc7Xeiy21VhEEi4Ik+quRySfb7ubDfJGhiUq4MQW43FhWJvg==",
+            "dev": true,
+            "dependencies": {
+                "@graphql-tools/import": "^6.6.6",
+                "@graphql-tools/utils": "^8.6.2",
+                "globby": "^11.0.3",
+                "tslib": "~2.3.0",
+                "unixify": "^1.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/graphql-file-loader/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
+        "node_modules/@graphql-tools/graphql-tag-pluck": {
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-7.1.6.tgz",
+            "integrity": "sha512-VdubvdS8pIrAPVDq6hV7ARXz2Yh8/2153+RO6i+RJOMgyFw8wOW3jRCKE93eN+Hk2pZBC2x3kzdNeUAyVpuslg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/parser": "^7.16.8",
+                "@babel/traverse": "^7.16.8",
+                "@babel/types": "^7.16.8",
+                "@graphql-tools/utils": "^8.6.2",
+                "tslib": "~2.3.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/graphql-tag-pluck/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
+        "node_modules/@graphql-tools/import": {
+            "version": "6.6.6",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.6.6.tgz",
+            "integrity": "sha512-a0aVajxqu1MsL8EwavA44Osw20lBOIhq8IM2ZIHFPP62cPAcOB26P+Sq57DHMsSyX5YQ0ab9XPM2o4e1dQhs0w==",
+            "dev": true,
+            "dependencies": {
+                "@graphql-tools/utils": "8.6.2",
+                "resolve-from": "5.0.0",
+                "tslib": "~2.3.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/import/node_modules/resolve-from": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+            "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@graphql-tools/import/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
+        "node_modules/@graphql-tools/json-file-loader": {
+            "version": "7.3.4",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.3.4.tgz",
+            "integrity": "sha512-1AROMFh8Lyorf2gTWXgVaUbU3ic84gzAgpRmJCsCla/Nnvn6JiCs4aWHsalk4ZWVXCaK04c8gk8Px1uNQUj02Q==",
+            "dev": true,
+            "dependencies": {
+                "@graphql-tools/utils": "^8.6.2",
+                "globby": "^11.0.3",
+                "tslib": "~2.3.0",
+                "unixify": "^1.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/json-file-loader/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
+        "node_modules/@graphql-tools/load": {
+            "version": "7.5.2",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.5.2.tgz",
+            "integrity": "sha512-URPqVP77mYxdZxT895DzrWf2C23S3yC/oAmXD4D4YlxR5eVVH/fxu0aZR78WcEKF331fWSiFwWy9j7BZWvkj7g==",
+            "dev": true,
+            "dependencies": {
+                "@graphql-tools/schema": "8.3.2",
+                "@graphql-tools/utils": "^8.6.2",
+                "p-limit": "3.1.0",
+                "tslib": "~2.3.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/load/node_modules/p-limit": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+            "dev": true,
+            "dependencies": {
+                "yocto-queue": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@graphql-tools/load/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
+        "node_modules/@graphql-tools/merge": {
+            "version": "8.2.3",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.3.tgz",
+            "integrity": "sha512-XCSmL6/Xg8259OTWNp69B57CPWiVL69kB7pposFrufG/zaAlI9BS68dgzrxmmSqZV5ZHU4r/6Tbf6fwnEJGiSw==",
+            "dev": true,
+            "dependencies": {
+                "@graphql-tools/utils": "^8.6.2",
+                "tslib": "~2.3.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/merge/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
+        "node_modules/@graphql-tools/optimize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/optimize/-/optimize-1.2.0.tgz",
+            "integrity": "sha512-l0PTqgHeorQdeOizUor6RB49eOAng9+abSxiC5/aHRo6hMmXVaqv5eqndlmxCpx9BkgNb3URQbK+ZZHVktkP/g==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "~2.3.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/optimize/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
+        "node_modules/@graphql-tools/prisma-loader": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/prisma-loader/-/prisma-loader-7.1.2.tgz",
+            "integrity": "sha512-AK/MIEaCDtcV41JTtdTmRBV8I6DM102FWJDbb3rTOVtIYSjU62G23yrPca8aMVcnIneQQNJ7MKYO18agCYXzqw==",
+            "dev": true,
+            "dependencies": {
+                "@graphql-tools/url-loader": "^7.7.2",
+                "@graphql-tools/utils": "^8.6.2",
+                "@types/js-yaml": "^4.0.0",
+                "@types/json-stable-stringify": "^1.0.32",
+                "@types/jsonwebtoken": "^8.5.0",
+                "chalk": "^4.1.0",
+                "debug": "^4.3.1",
+                "dotenv": "^16.0.0",
+                "graphql-request": "^4.0.0",
+                "http-proxy-agent": "^5.0.0",
+                "https-proxy-agent": "^5.0.0",
+                "isomorphic-fetch": "^3.0.0",
+                "js-yaml": "^4.0.0",
+                "json-stable-stringify": "^1.0.1",
+                "jsonwebtoken": "^8.5.1",
+                "lodash": "^4.17.20",
+                "replaceall": "^0.1.6",
+                "scuid": "^1.1.0",
+                "tslib": "~2.3.0",
+                "yaml-ast-parser": "^0.0.43"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/prisma-loader/node_modules/@tootallnate/once": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+            "dev": true,
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@graphql-tools/prisma-loader/node_modules/extract-files": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-9.0.0.tgz",
+            "integrity": "sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==",
+            "dev": true,
+            "engines": {
+                "node": "^10.17.0 || ^12.0.0 || >= 13.7.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jaydenseric"
+            }
+        },
+        "node_modules/@graphql-tools/prisma-loader/node_modules/graphql-request": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-4.0.0.tgz",
+            "integrity": "sha512-cdqQLCXlBGkaLdkLYRl4LtkwaZU6TfpE7/tnUQFl3wXfUPWN74Ov+Q61VuIh+AltS789YfGB6whghmCmeXLvTw==",
+            "dev": true,
+            "dependencies": {
+                "cross-fetch": "^3.0.6",
+                "extract-files": "^9.0.0",
+                "form-data": "^3.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "14 - 16"
+            }
+        },
+        "node_modules/@graphql-tools/prisma-loader/node_modules/http-proxy-agent": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+            "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+            "dev": true,
+            "dependencies": {
+                "@tootallnate/once": "2",
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/@graphql-tools/prisma-loader/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
+        "node_modules/@graphql-tools/relay-operation-optimizer": {
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.4.2.tgz",
+            "integrity": "sha512-pc/cliYO0veVbMyM5H54lZzQh+9SxnjawqR623rc+jPuY9JUQcuIKkZzM1+E5blbtr4dvh7Bi4uzf3rJ0sxG0Q==",
+            "dev": true,
+            "dependencies": {
+                "@graphql-tools/utils": "^8.6.2",
+                "relay-compiler": "12.0.0",
+                "tslib": "~2.3.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/relay-operation-optimizer/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
+        "node_modules/@graphql-tools/schema": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.3.2.tgz",
+            "integrity": "sha512-77feSmIuHdoxMXRbRyxE8rEziKesd/AcqKV6fmxe7Zt+PgIQITxNDew2XJJg7qFTMNM43W77Ia6njUSBxNOkwg==",
+            "dev": true,
+            "dependencies": {
+                "@graphql-tools/merge": "^8.2.3",
+                "@graphql-tools/utils": "^8.6.2",
+                "tslib": "~2.3.0",
+                "value-or-promise": "1.0.11"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/schema/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
+        "node_modules/@graphql-tools/url-loader": {
+            "version": "7.7.2",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.7.2.tgz",
+            "integrity": "sha512-7qDLs7zvFg3shr6UDvArYTlhezjsulIGt7bUIve3nZZDgs/x8EAKeod4/+pt1ZUYq19aSMt19N1Een0F+xWWsA==",
+            "dev": true,
+            "dependencies": {
+                "@graphql-tools/delegate": "^8.5.1",
+                "@graphql-tools/utils": "^8.6.2",
+                "@graphql-tools/wrap": "^8.4.2",
+                "@n1ru4l/graphql-live-query": "^0.9.0",
+                "@types/websocket": "^1.0.4",
+                "@types/ws": "^8.0.0",
+                "cross-undici-fetch": "^0.1.19",
+                "dset": "^3.1.0",
+                "extract-files": "^11.0.0",
+                "graphql-sse": "^1.0.1",
+                "graphql-ws": "^5.4.1",
+                "isomorphic-ws": "^4.0.1",
+                "meros": "^1.1.4",
+                "subscriptions-transport-ws": "^0.11.0",
+                "sync-fetch": "^0.3.1",
+                "tslib": "^2.3.0",
+                "valid-url": "^1.0.9",
+                "value-or-promise": "^1.0.11",
+                "ws": "^8.3.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/url-loader/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
+        "node_modules/@graphql-tools/url-loader/node_modules/ws": {
+            "version": "8.5.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+            "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+            "dev": true,
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": "^5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@graphql-tools/utils": {
+            "version": "8.6.2",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
+            "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "~2.3.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/utils/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
+        "node_modules/@graphql-tools/wrap": {
+            "version": "8.4.2",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.4.2.tgz",
+            "integrity": "sha512-U6vpfOhp+uyTNsDi1wbk0dpCn6oJ3CmRS2EUpyuzHQDC7YQgAElxn5Wl/eDsKmhJGzGDODKY9M6yHAEH/tRrPQ==",
+            "dev": true,
+            "dependencies": {
+                "@graphql-tools/delegate": "^8.5.1",
+                "@graphql-tools/schema": "^8.3.2",
+                "@graphql-tools/utils": "^8.6.2",
+                "tslib": "~2.3.0",
+                "value-or-promise": "1.0.11"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/wrap/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
         "node_modules/@grpc/grpc-js": {
             "version": "1.5.5",
             "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.5.5.tgz",
@@ -951,6 +2251,12 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
             "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+            "dev": true
+        },
+        "node_modules/@iarna/toml": {
+            "version": "2.2.5",
+            "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+            "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
             "dev": true
         },
         "node_modules/@istanbuljs/load-nyc-config": {
@@ -1249,6 +2555,15 @@
                 "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
             }
         },
+        "node_modules/@n1ru4l/graphql-live-query": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/@n1ru4l/graphql-live-query/-/graphql-live-query-0.9.0.tgz",
+            "integrity": "sha512-BTpWy1e+FxN82RnLz4x1+JcEewVdfmUhV1C6/XYD5AjS7PQp9QFF7K8bCD6gzPTr2l+prvqOyVueQhFJxB1vfg==",
+            "dev": true,
+            "peerDependencies": {
+                "graphql": "^15.4.0 || ^16.0.0"
+            }
+        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1370,6 +2685,26 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
             "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+        },
+        "node_modules/@samverschueren/stream-to-observable": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz",
+            "integrity": "sha512-c/qwwcHyafOQuVQJj0IlBjf5yYgBI7YPJ77k4fOJYesb41jio65eaJODRUmfYKhTOFBrIZ66kgvGPlNbjuoRdQ==",
+            "dev": true,
+            "dependencies": {
+                "any-observable": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "peerDependenciesMeta": {
+                "rxjs": {
+                    "optional": true
+                },
+                "zen-observable": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/@sindresorhus/is": {
             "version": "0.14.0",
@@ -1619,6 +2954,16 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/graphql": {
+            "version": "14.5.0",
+            "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-14.5.0.tgz",
+            "integrity": "sha512-MOkzsEp1Jk5bXuAsHsUi6BVv0zCO+7/2PTiZMXWDSsMXvNU6w/PLMQT2vHn8hy2i0JqojPz1Sz6rsFjHtsU0lA==",
+            "deprecated": "This is a stub types definition. graphql provides its own type definitions, so you do not need this installed.",
+            "dev": true,
+            "dependencies": {
+                "graphql": "*"
+            }
+        },
         "node_modules/@types/istanbul-lib-coverage": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
@@ -1653,10 +2998,22 @@
                 "pretty-format": "^27.0.0"
             }
         },
+        "node_modules/@types/js-yaml": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz",
+            "integrity": "sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==",
+            "dev": true
+        },
         "node_modules/@types/json-schema": {
             "version": "7.0.9",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
             "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+            "dev": true
+        },
+        "node_modules/@types/json-stable-stringify": {
+            "version": "1.0.33",
+            "resolved": "https://registry.npmjs.org/@types/json-stable-stringify/-/json-stable-stringify-1.0.33.tgz",
+            "integrity": "sha512-qEWiQff6q2tA5gcJGWwzplQcXdJtm+0oy6IHGHzlOf3eFAkGE/FIPXZK9ofWgNSHVp8AFFI33PJJshS0ei3Gvw==",
             "dev": true
         },
         "node_modules/@types/json5": {
@@ -1664,6 +3021,15 @@
             "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
             "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
             "dev": true
+        },
+        "node_modules/@types/jsonwebtoken": {
+            "version": "8.5.8",
+            "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.8.tgz",
+            "integrity": "sha512-zm6xBQpFDIDM6o9r6HSgDeIcLy82TKWctCXEPbJJcXb5AKmi5BNNdLXneixK4lplX3PqIVcwLBCGE/kAGnlD4A==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@types/long": {
             "version": "4.0.1",
@@ -1694,6 +3060,12 @@
                 "@types/node": "*",
                 "form-data": "^3.0.0"
             }
+        },
+        "node_modules/@types/parse-json": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+            "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+            "dev": true
         },
         "node_modules/@types/prettier": {
             "version": "2.4.4",
@@ -1746,6 +3118,24 @@
             "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
             "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
             "dev": true
+        },
+        "node_modules/@types/websocket": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.5.tgz",
+            "integrity": "sha512-NbsqiNX9CnEfC1Z0Vf4mE1SgAJ07JnRYcNex7AJ9zAVzmiGHmjKFEk7O4TJIsgv2B1sLEb6owKFZrACwdYngsQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/ws": {
+            "version": "8.5.1",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.1.tgz",
+            "integrity": "sha512-UxlLOfkuQnT2YSBCNq0x86SGOUxas6gAySFeDe2DcnEnA8655UIPoCDorWZCugcvKIL8IUI4oueUfJ1hhZSE2A==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@types/yargs": {
             "version": "16.0.4",
@@ -2118,6 +3508,15 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
+        "node_modules/any-observable": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
+            "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/anymatch": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
@@ -2190,6 +3589,12 @@
                 "node": ">=8"
             }
         },
+        "node_modules/asap": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+            "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+            "dev": true
+        },
         "node_modules/asn1": {
             "version": "0.2.4",
             "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -2238,6 +3643,18 @@
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
         },
+        "node_modules/auto-bind": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz",
+            "integrity": "sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/aws-sign2": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -2275,6 +3692,15 @@
                 "@babel/core": "^7.8.0"
             }
         },
+        "node_modules/babel-plugin-dynamic-import-node": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+            "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
+            "dev": true,
+            "dependencies": {
+                "object.assign": "^4.1.0"
+            }
+        },
         "node_modules/babel-plugin-istanbul": {
             "version": "6.1.1",
             "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
@@ -2306,6 +3732,12 @@
                 "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
             }
         },
+        "node_modules/babel-plugin-syntax-trailing-function-commas": {
+            "version": "7.0.0-beta.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz",
+            "integrity": "sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==",
+            "dev": true
+        },
         "node_modules/babel-preset-current-node-syntax": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
@@ -2329,6 +3761,44 @@
                 "@babel/core": "^7.0.0"
             }
         },
+        "node_modules/babel-preset-fbjs": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-3.4.0.tgz",
+            "integrity": "sha512-9ywCsCvo1ojrw0b+XYk7aFvTH6D9064t0RIL1rtMf3nsa02Xw41MS7sZw216Im35xj/UY0PDBQsa1brUDDF1Ow==",
+            "dev": true,
+            "dependencies": {
+                "@babel/plugin-proposal-class-properties": "^7.0.0",
+                "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+                "@babel/plugin-syntax-class-properties": "^7.0.0",
+                "@babel/plugin-syntax-flow": "^7.0.0",
+                "@babel/plugin-syntax-jsx": "^7.0.0",
+                "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+                "@babel/plugin-transform-arrow-functions": "^7.0.0",
+                "@babel/plugin-transform-block-scoped-functions": "^7.0.0",
+                "@babel/plugin-transform-block-scoping": "^7.0.0",
+                "@babel/plugin-transform-classes": "^7.0.0",
+                "@babel/plugin-transform-computed-properties": "^7.0.0",
+                "@babel/plugin-transform-destructuring": "^7.0.0",
+                "@babel/plugin-transform-flow-strip-types": "^7.0.0",
+                "@babel/plugin-transform-for-of": "^7.0.0",
+                "@babel/plugin-transform-function-name": "^7.0.0",
+                "@babel/plugin-transform-literals": "^7.0.0",
+                "@babel/plugin-transform-member-expression-literals": "^7.0.0",
+                "@babel/plugin-transform-modules-commonjs": "^7.0.0",
+                "@babel/plugin-transform-object-super": "^7.0.0",
+                "@babel/plugin-transform-parameters": "^7.0.0",
+                "@babel/plugin-transform-property-literals": "^7.0.0",
+                "@babel/plugin-transform-react-display-name": "^7.0.0",
+                "@babel/plugin-transform-react-jsx": "^7.0.0",
+                "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+                "@babel/plugin-transform-spread": "^7.0.0",
+                "@babel/plugin-transform-template-literals": "^7.0.0",
+                "babel-plugin-syntax-trailing-function-commas": "^7.0.0-beta.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
         "node_modules/babel-preset-jest": {
             "version": "27.5.1",
             "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-27.5.1.tgz",
@@ -2344,6 +3814,12 @@
             "peerDependencies": {
                 "@babel/core": "^7.0.0"
             }
+        },
+        "node_modules/backo2": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+            "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
+            "dev": true
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",
@@ -2605,6 +4081,30 @@
                 "node-int64": "^0.4.0"
             }
         },
+        "node_modules/buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
+            }
+        },
         "node_modules/buffer-alloc": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
@@ -2728,6 +4228,22 @@
                 "node": ">=6"
             }
         },
+        "node_modules/camel-case": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+            "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+            "dev": true,
+            "dependencies": {
+                "pascal-case": "^3.1.2",
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/camel-case/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
         "node_modules/camelcase": {
             "version": "5.3.1",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -2746,6 +4262,23 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/browserslist"
             }
+        },
+        "node_modules/capital-case": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
+            "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
+            "dev": true,
+            "dependencies": {
+                "no-case": "^3.0.4",
+                "tslib": "^2.0.3",
+                "upper-case-first": "^2.0.2"
+            }
+        },
+        "node_modules/capital-case/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
         },
         "node_modules/caseless": {
             "version": "0.12.0",
@@ -2781,6 +4314,50 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
+        "node_modules/change-case": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+            "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+            "dev": true,
+            "dependencies": {
+                "camel-case": "^4.1.2",
+                "capital-case": "^1.0.4",
+                "constant-case": "^3.0.4",
+                "dot-case": "^3.0.4",
+                "header-case": "^2.0.4",
+                "no-case": "^3.0.4",
+                "param-case": "^3.0.4",
+                "pascal-case": "^3.1.2",
+                "path-case": "^3.0.4",
+                "sentence-case": "^3.0.4",
+                "snake-case": "^3.0.4",
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/change-case-all": {
+            "version": "1.0.14",
+            "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.14.tgz",
+            "integrity": "sha512-CWVm2uT7dmSHdO/z1CXT/n47mWonyypzBbuCy5tN7uMg22BsfkhwT6oHmFCAk+gL1LOOxhdbB9SZz3J1KTY3gA==",
+            "dev": true,
+            "dependencies": {
+                "change-case": "^4.1.2",
+                "is-lower-case": "^2.0.2",
+                "is-upper-case": "^2.0.2",
+                "lower-case": "^2.0.2",
+                "lower-case-first": "^2.0.2",
+                "sponge-case": "^1.0.1",
+                "swap-case": "^2.0.2",
+                "title-case": "^3.0.3",
+                "upper-case": "^2.0.2",
+                "upper-case-first": "^2.0.2"
+            }
+        },
+        "node_modules/change-case/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
         "node_modules/char-regex": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
@@ -2789,6 +4366,12 @@
             "engines": {
                 "node": ">=10"
             }
+        },
+        "node_modules/chardet": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+            "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+            "dev": true
         },
         "node_modules/chokidar": {
             "version": "3.5.2",
@@ -2866,6 +4449,30 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/cli-cursor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+            "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+            "dev": true,
+            "dependencies": {
+                "restore-cursor": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cli-spinners": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
+            "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/cli-table": {
             "version": "0.3.6",
             "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.6.tgz",
@@ -2878,6 +4485,75 @@
                 "node": ">= 0.2.0"
             }
         },
+        "node_modules/cli-truncate": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+            "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+            "dev": true,
+            "dependencies": {
+                "slice-ansi": "0.0.4",
+                "string-width": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/cli-truncate/node_modules/ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/cli-truncate/node_modules/is-fullwidth-code-point": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+            "dev": true,
+            "dependencies": {
+                "number-is-nan": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/cli-truncate/node_modules/string-width": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+            "dev": true,
+            "dependencies": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/cli-truncate/node_modules/strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/cli-width": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+            "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 10"
+            }
+        },
         "node_modules/cliui": {
             "version": "7.0.4",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -2886,6 +4562,15 @@
                 "string-width": "^4.2.0",
                 "strip-ansi": "^6.0.0",
                 "wrap-ansi": "^7.0.0"
+            }
+        },
+        "node_modules/clone": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+            "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8"
             }
         },
         "node_modules/clone-response": {
@@ -2905,6 +4590,15 @@
             "engines": {
                 "iojs": ">= 1.0.0",
                 "node": ">= 0.12.0"
+            }
+        },
+        "node_modules/code-point-at": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/collect-v8-coverage": {
@@ -2994,6 +4688,15 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
             "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
         },
+        "node_modules/common-tags": {
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
+            "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
+            "dev": true,
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3033,6 +4736,23 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/console-log-level/-/console-log-level-1.4.1.tgz",
             "integrity": "sha512-VZzbIORbP+PPcN/gg3DXClTLPLg5Slwd5fL2MIc+o1qZ4BXBvWyc6QxPk6T/Mkr6IVjRpoAGf32XxP3ZWMVRcQ=="
+        },
+        "node_modules/constant-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+            "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+            "dev": true,
+            "dependencies": {
+                "no-case": "^3.0.4",
+                "tslib": "^2.0.3",
+                "upper-case": "^2.0.2"
+            }
+        },
+        "node_modules/constant-case/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
         },
         "node_modules/content-disposition": {
             "version": "0.5.4",
@@ -3128,6 +4848,31 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/cosmiconfig": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+            "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/parse-json": "^4.0.0",
+                "import-fresh": "^3.2.1",
+                "parse-json": "^5.0.0",
+                "path-type": "^4.0.0",
+                "yaml": "^1.10.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/cosmiconfig-toml-loader": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig-toml-loader/-/cosmiconfig-toml-loader-1.0.0.tgz",
+            "integrity": "sha512-H/2gurFWVi7xXvCyvsWRLCMekl4tITJcX0QEsDMpzxtuxDyM59xLatYNg4s/k9AA/HdtCYfj2su8mgA0GSDLDA==",
+            "dev": true,
+            "dependencies": {
+                "@iarna/toml": "^2.2.5"
+            }
+        },
         "node_modules/create-eslint-index": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/create-eslint-index/-/create-eslint-index-1.0.0.tgz",
@@ -3146,6 +4891,14 @@
             "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
             "dev": true
         },
+        "node_modules/cross-fetch": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+            "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+            "dependencies": {
+                "node-fetch": "2.6.7"
+            }
+        },
         "node_modules/cross-spawn": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -3158,6 +4911,20 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/cross-undici-fetch": {
+            "version": "0.1.25",
+            "resolved": "https://registry.npmjs.org/cross-undici-fetch/-/cross-undici-fetch-0.1.25.tgz",
+            "integrity": "sha512-KS6hm/VuRO+3jIrg4uidz3mQ8NWvCbiTTOg3yoH30zuGVUvjqZlnXw66h0kuzyfP21hDkrdIbufXCW6BAQdSNw==",
+            "dev": true,
+            "dependencies": {
+                "abort-controller": "^3.0.0",
+                "form-data-encoder": "^1.7.1",
+                "formdata-node": "^4.3.1",
+                "node-fetch": "^2.6.7",
+                "undici": "^4.9.3",
+                "web-streams-polyfill": "^3.2.0"
             }
         },
         "node_modules/crypto-random-string": {
@@ -3219,6 +4986,12 @@
                 "node": ">=10"
             }
         },
+        "node_modules/dataloader": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.0.0.tgz",
+            "integrity": "sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ==",
+            "dev": true
+        },
         "node_modules/date-fns": {
             "version": "2.28.0",
             "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
@@ -3230,6 +5003,12 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/date-fns"
             }
+        },
+        "node_modules/debounce": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+            "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+            "dev": true
         },
         "node_modules/debug": {
             "version": "4.3.2",
@@ -3245,6 +5024,15 @@
                 "supports-color": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/decimal.js": {
@@ -3295,11 +5083,32 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/defaults": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+            "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+            "dev": true,
+            "dependencies": {
+                "clone": "^1.0.2"
+            }
+        },
         "node_modules/defer-to-connect": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
             "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
             "dev": true
+        },
+        "node_modules/define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "dev": true,
+            "dependencies": {
+                "object-keys": "^1.0.12"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
         },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
@@ -3325,10 +5134,28 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/dependency-graph": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
+            "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.6.0"
+            }
+        },
         "node_modules/destroy": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
             "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+        },
+        "node_modules/detect-indent": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+            "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/detect-newline": {
             "version": "3.1.0",
@@ -3402,6 +5229,22 @@
                 "node": ">=8"
             }
         },
+        "node_modules/dot-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+            "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+            "dev": true,
+            "dependencies": {
+                "no-case": "^3.0.4",
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/dot-case/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
         "node_modules/dot-prop": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
@@ -3414,6 +5257,24 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/dotenv": {
+            "version": "16.0.0",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
+            "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/dset": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.1.tgz",
+            "integrity": "sha512-hYf+jZNNqJBD2GiMYb+5mqOIX4R4RRHXU3qWMWYN+rqcR2/YpRL2bUHr8C8fU+5DNvqYjJ8YvMGSLuVPWU1cNg==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/duplexer3": {
@@ -3461,6 +5322,15 @@
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.886.tgz",
             "integrity": "sha512-+vYdeBosI63VkCtNWnEVFjgNd/IZwvnsWkKyPtWAvrhA+XfByKoBJcbsMgudVU/bUcGAF9Xp3aXn96voWlc3oQ==",
             "dev": true
+        },
+        "node_modules/elegant-spinner": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+            "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/emitter-listener": {
             "version": "1.1.2",
@@ -3922,6 +5792,12 @@
                 "node": ">=6"
             }
         },
+        "node_modules/eventemitter3": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+            "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+            "dev": true
+        },
         "node_modules/eventid": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/eventid/-/eventid-2.0.1.tgz",
@@ -4087,6 +5963,44 @@
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
             "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
         },
+        "node_modules/external-editor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+            "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+            "dev": true,
+            "dependencies": {
+                "chardet": "^0.7.0",
+                "iconv-lite": "^0.4.24",
+                "tmp": "^0.0.33"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/external-editor/node_modules/tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "dev": true,
+            "dependencies": {
+                "os-tmpdir": "~1.0.2"
+            },
+            "engines": {
+                "node": ">=0.6.0"
+            }
+        },
+        "node_modules/extract-files": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-11.0.0.tgz",
+            "integrity": "sha512-FuoE1qtbJ4bBVvv94CC7s0oTnKUGvQs+Rjf1L2SJFfS+HTVVjhPFtehPdQ0JiGPqVNfSSZvL5yzHHQq2Z4WNhQ==",
+            "dev": true,
+            "engines": {
+                "node": "^12.20 || >= 14.13"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jaydenseric"
+            }
+        },
         "node_modules/extsprintf": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -4171,10 +6085,55 @@
                 "bser": "2.1.1"
             }
         },
+        "node_modules/fbjs": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.4.tgz",
+            "integrity": "sha512-ucV0tDODnGV3JCnnkmoszb5lf4bNpzjv80K41wd4k798Etq+UYD0y0TIfalLjZoKgjive6/adkRnszwapiDgBQ==",
+            "dev": true,
+            "dependencies": {
+                "cross-fetch": "^3.1.5",
+                "fbjs-css-vars": "^1.0.0",
+                "loose-envify": "^1.0.0",
+                "object-assign": "^4.1.0",
+                "promise": "^7.1.1",
+                "setimmediate": "^1.0.5",
+                "ua-parser-js": "^0.7.30"
+            }
+        },
+        "node_modules/fbjs-css-vars": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
+            "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==",
+            "dev": true
+        },
         "node_modules/fecha": {
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
             "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q=="
+        },
+        "node_modules/figures": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+            "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+            "dev": true,
+            "dependencies": {
+                "escape-string-regexp": "^1.0.5"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/figures/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
         },
         "node_modules/file-entry-cache": {
             "version": "6.0.1",
@@ -4287,6 +6246,34 @@
             },
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/form-data-encoder": {
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.1.tgz",
+            "integrity": "sha512-EFRDrsMm/kyqbTQocNvRXMLjc7Es2Vk+IQFx/YW7hkUH1eBl4J1fqiP34l74Yt0pFLCNpc06fkbVk00008mzjg==",
+            "dev": true
+        },
+        "node_modules/formdata-node": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.3.2.tgz",
+            "integrity": "sha512-k7lYJyzDOSL6h917favP8j1L0/wNyylzU+x+1w4p5haGVHNlP58dbpdJhiCUsDbWsa9HwEtLp89obQgXl2e0qg==",
+            "dev": true,
+            "dependencies": {
+                "node-domexception": "1.0.0",
+                "web-streams-polyfill": "4.0.0-beta.1"
+            },
+            "engines": {
+                "node": ">= 12.20"
+            }
+        },
+        "node_modules/formdata-node/node_modules/web-streams-polyfill": {
+            "version": "4.0.0-beta.1",
+            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.1.tgz",
+            "integrity": "sha512-3ux37gEX670UUphBF9AMCq8XM6iQ8Ac6A+DSRRjDoRBm1ufCkaCDdNVbaqq60PsEkdNlLKrGtv/YBP4EJXqNtQ==",
+            "dev": true,
+            "engines": {
+                "node": ">= 12"
             }
         },
         "node_modules/forwarded": {
@@ -4648,6 +6635,120 @@
             "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
             "dev": true
         },
+        "node_modules/graphql": {
+            "version": "15.8.0",
+            "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+            "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
+            "engines": {
+                "node": ">= 10.x"
+            }
+        },
+        "node_modules/graphql-config": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-4.1.0.tgz",
+            "integrity": "sha512-Myqay6pmdcmX3KqoH+bMbeKZ1cTODpHS2CxF1ZzNnfTE+YUpGTcp01bOw6LpzamRb0T/WTYtGFbZeXGo9Hab2Q==",
+            "dev": true,
+            "dependencies": {
+                "@endemolshinegroup/cosmiconfig-typescript-loader": "3.0.2",
+                "@graphql-tools/graphql-file-loader": "^7.3.2",
+                "@graphql-tools/json-file-loader": "^7.3.2",
+                "@graphql-tools/load": "^7.4.1",
+                "@graphql-tools/merge": "^8.2.1",
+                "@graphql-tools/url-loader": "^7.4.2",
+                "@graphql-tools/utils": "^8.5.1",
+                "cosmiconfig": "7.0.1",
+                "cosmiconfig-toml-loader": "1.0.0",
+                "minimatch": "3.0.4",
+                "string-env-interpolation": "1.0.1"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+            }
+        },
+        "node_modules/graphql-executor": {
+            "version": "0.0.18",
+            "resolved": "https://registry.npmjs.org/graphql-executor/-/graphql-executor-0.0.18.tgz",
+            "integrity": "sha512-upUSl7tfZCZ5dWG1XkOvpG70Yk3duZKcCoi/uJso4WxJVT6KIrcK4nZ4+2X/hzx46pL8wAukgYHY6iNmocRN+g==",
+            "dev": true,
+            "engines": {
+                "node": "^12.22.0 || ^14.16.0 || >=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^15.0.0 || ^16.0.0"
+            }
+        },
+        "node_modules/graphql-request": {
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-3.7.0.tgz",
+            "integrity": "sha512-dw5PxHCgBneN2DDNqpWu8QkbbJ07oOziy8z+bK/TAXufsOLaETuVO4GkXrbs0WjhdKhBMN3BkpN/RIvUHkmNUQ==",
+            "dependencies": {
+                "cross-fetch": "^3.0.6",
+                "extract-files": "^9.0.0",
+                "form-data": "^3.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "14 - 16"
+            }
+        },
+        "node_modules/graphql-request/node_modules/extract-files": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-9.0.0.tgz",
+            "integrity": "sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==",
+            "engines": {
+                "node": "^10.17.0 || ^12.0.0 || >= 13.7.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jaydenseric"
+            }
+        },
+        "node_modules/graphql-sse": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/graphql-sse/-/graphql-sse-1.0.6.tgz",
+            "integrity": "sha512-y2mVBN2KwNrzxX2KBncQ6kzc6JWvecxuBernrl0j65hsr6MAS3+Yn8PTFSOgRmtolxugepxveyZVQEuaNEbw3w==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "peerDependencies": {
+                "graphql": ">=0.11 <=16"
+            }
+        },
+        "node_modules/graphql-tag": {
+            "version": "2.12.6",
+            "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+            "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+            }
+        },
+        "node_modules/graphql-tag/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
+        "node_modules/graphql-ws": {
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.6.2.tgz",
+            "integrity": "sha512-TsjovINNEGfv52uKWYSVCOLX9LFe6wAhf9n7hIsV3zjflky1dv/mAP+kjXAXsnzV1jH5Sx0S73CtBFNvxus+SQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "graphql": ">=0.11 <=16"
+            }
+        },
         "node_modules/gtoken": {
             "version": "5.3.1",
             "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.3.1.tgz",
@@ -4695,6 +6796,27 @@
                 "node": ">= 0.4.0"
             }
         },
+        "node_modules/has-ansi": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/has-ansi/node_modules/ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -4723,6 +6845,22 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/header-case": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+            "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+            "dev": true,
+            "dependencies": {
+                "capital-case": "^1.0.4",
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/header-case/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
         },
         "node_modules/hex2dec": {
             "version": "1.1.2",
@@ -4829,6 +6967,26 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
+        },
         "node_modules/ignore": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -4850,6 +7008,15 @@
             "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
             "dev": true
         },
+        "node_modules/immutable": {
+            "version": "3.7.6",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
+            "integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
         "node_modules/import-fresh": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -4861,6 +7028,18 @@
             },
             "engines": {
                 "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/import-from": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
+            "integrity": "sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=12.2"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -4903,6 +7082,15 @@
                 "node": ">=0.8.19"
             }
         },
+        "node_modules/indent-string": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+            "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -4927,6 +7115,40 @@
                 "node": ">=10"
             }
         },
+        "node_modules/inquirer": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.0.tgz",
+            "integrity": "sha512-0crLweprevJ02tTuA6ThpoAERAGyVILC4sS74uib58Xf/zSr1/ZWtmm7D5CI+bSQEaA04f0K7idaHpQbSWgiVQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-escapes": "^4.2.1",
+                "chalk": "^4.1.1",
+                "cli-cursor": "^3.1.0",
+                "cli-width": "^3.0.0",
+                "external-editor": "^3.0.3",
+                "figures": "^3.0.0",
+                "lodash": "^4.17.21",
+                "mute-stream": "0.0.8",
+                "ora": "^5.4.1",
+                "run-async": "^2.4.0",
+                "rxjs": "^7.2.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0",
+                "through": "^2.3.6"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/invariant": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+            "dev": true,
+            "dependencies": {
+                "loose-envify": "^1.0.0"
+            }
+        },
         "node_modules/ipaddr.js": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -4941,6 +7163,19 @@
             "integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg==",
             "engines": {
                 "node": "*"
+            }
+        },
+        "node_modules/is-absolute": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+            "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+            "dev": true,
+            "dependencies": {
+                "is-relative": "^1.0.0",
+                "is-windows": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/is-arrayish": {
@@ -5043,6 +7278,30 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/is-interactive": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+            "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/is-lower-case": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-2.0.2.tgz",
+            "integrity": "sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/is-lower-case/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
         "node_modules/is-npm": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-5.0.0.tgz",
@@ -5072,6 +7331,18 @@
                 "node": ">=8"
             }
         },
+        "node_modules/is-observable": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
+            "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
+            "dev": true,
+            "dependencies": {
+                "symbol-observable": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/is-path-inside": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -5086,6 +7357,24 @@
             "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
             "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
             "dev": true
+        },
+        "node_modules/is-promise": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+            "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+            "dev": true
+        },
+        "node_modules/is-relative": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+            "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+            "dev": true,
+            "dependencies": {
+                "is-unc-path": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/is-stream": {
             "version": "2.0.1",
@@ -5109,6 +7398,54 @@
             "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
             "dev": true
         },
+        "node_modules/is-unc-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+            "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+            "dev": true,
+            "dependencies": {
+                "unc-path-regex": "^0.1.2"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-unicode-supported": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+            "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-upper-case": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-2.0.2.tgz",
+            "integrity": "sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/is-upper-case/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
+        "node_modules/is-windows": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/is-yarn-global": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
@@ -5126,6 +7463,25 @@
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
             "dev": true
+        },
+        "node_modules/isomorphic-fetch": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+            "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+            "dev": true,
+            "dependencies": {
+                "node-fetch": "^2.6.1",
+                "whatwg-fetch": "^3.4.1"
+            }
+        },
+        "node_modules/isomorphic-ws": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+            "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+            "dev": true,
+            "peerDependencies": {
+                "ws": "*"
+            }
         },
         "node_modules/isstream": {
             "version": "0.1.2",
@@ -5207,6 +7563,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/iterall": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+            "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
+            "dev": true
         },
         "node_modules/jest": {
             "version": "27.5.1",
@@ -5949,6 +8311,15 @@
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
         },
+        "node_modules/json-stable-stringify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+            "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+            "dev": true,
+            "dependencies": {
+                "jsonify": "~0.0.0"
+            }
+        },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -5960,6 +8331,19 @@
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
             "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
             "dev": true
+        },
+        "node_modules/json-to-pretty-yaml": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/json-to-pretty-yaml/-/json-to-pretty-yaml-1.2.2.tgz",
+            "integrity": "sha1-9M0L0KXo/h3yWq9boRiwmf2ZLVs=",
+            "dev": true,
+            "dependencies": {
+                "remedial": "^1.0.7",
+                "remove-trailing-spaces": "^1.0.6"
+            },
+            "engines": {
+                "node": ">= 0.2.0"
+            }
         },
         "node_modules/json5": {
             "version": "2.2.0",
@@ -5983,6 +8367,15 @@
             "dev": true,
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/jsonify": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+            "dev": true,
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/jsonwebtoken": {
@@ -6195,6 +8588,317 @@
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
             "dev": true
         },
+        "node_modules/listr": {
+            "version": "0.14.3",
+            "resolved": "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz",
+            "integrity": "sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==",
+            "dev": true,
+            "dependencies": {
+                "@samverschueren/stream-to-observable": "^0.3.0",
+                "is-observable": "^1.1.0",
+                "is-promise": "^2.1.0",
+                "is-stream": "^1.1.0",
+                "listr-silent-renderer": "^1.1.1",
+                "listr-update-renderer": "^0.5.0",
+                "listr-verbose-renderer": "^0.5.0",
+                "p-map": "^2.0.0",
+                "rxjs": "^6.3.3"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/listr-silent-renderer": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+            "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/listr-update-renderer": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
+            "integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
+            "dev": true,
+            "dependencies": {
+                "chalk": "^1.1.3",
+                "cli-truncate": "^0.2.1",
+                "elegant-spinner": "^1.0.1",
+                "figures": "^1.7.0",
+                "indent-string": "^3.0.0",
+                "log-symbols": "^1.0.2",
+                "log-update": "^2.3.0",
+                "strip-ansi": "^3.0.1"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "peerDependencies": {
+                "listr": "^0.14.2"
+            }
+        },
+        "node_modules/listr-update-renderer/node_modules/ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/listr-update-renderer/node_modules/ansi-styles": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/listr-update-renderer/node_modules/chalk": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/listr-update-renderer/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/listr-update-renderer/node_modules/figures": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+            "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+            "dev": true,
+            "dependencies": {
+                "escape-string-regexp": "^1.0.5",
+                "object-assign": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/listr-update-renderer/node_modules/log-symbols": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+            "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+            "dev": true,
+            "dependencies": {
+                "chalk": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/listr-update-renderer/node_modules/strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/listr-update-renderer/node_modules/supports-color": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/listr-verbose-renderer": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
+            "integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
+            "dev": true,
+            "dependencies": {
+                "chalk": "^2.4.1",
+                "cli-cursor": "^2.1.0",
+                "date-fns": "^1.27.2",
+                "figures": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/listr-verbose-renderer/node_modules/ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/listr-verbose-renderer/node_modules/chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/listr-verbose-renderer/node_modules/cli-cursor": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+            "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+            "dev": true,
+            "dependencies": {
+                "restore-cursor": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/listr-verbose-renderer/node_modules/color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "1.1.3"
+            }
+        },
+        "node_modules/listr-verbose-renderer/node_modules/color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
+        },
+        "node_modules/listr-verbose-renderer/node_modules/date-fns": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+            "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+            "dev": true
+        },
+        "node_modules/listr-verbose-renderer/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/listr-verbose-renderer/node_modules/figures": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+            "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+            "dev": true,
+            "dependencies": {
+                "escape-string-regexp": "^1.0.5"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/listr-verbose-renderer/node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/listr-verbose-renderer/node_modules/mimic-fn": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+            "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/listr-verbose-renderer/node_modules/onetime": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+            "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+            "dev": true,
+            "dependencies": {
+                "mimic-fn": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/listr-verbose-renderer/node_modules/restore-cursor": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+            "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+            "dev": true,
+            "dependencies": {
+                "onetime": "^2.0.0",
+                "signal-exit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/listr-verbose-renderer/node_modules/supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/listr/node_modules/is-stream": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/listr/node_modules/rxjs": {
+            "version": "6.6.7",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+            "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^1.9.0"
+            },
+            "engines": {
+                "npm": ">=2.0.0"
+            }
+        },
         "node_modules/locate-path": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -6310,6 +9014,147 @@
                 "node": ">=0.8.6"
             }
         },
+        "node_modules/log-symbols": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+            "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+            "dev": true,
+            "dependencies": {
+                "chalk": "^4.1.0",
+                "is-unicode-supported": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/log-update": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
+            "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
+            "dev": true,
+            "dependencies": {
+                "ansi-escapes": "^3.0.0",
+                "cli-cursor": "^2.0.0",
+                "wrap-ansi": "^3.0.1"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/log-update/node_modules/ansi-escapes": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+            "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/log-update/node_modules/ansi-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+            "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/log-update/node_modules/cli-cursor": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+            "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+            "dev": true,
+            "dependencies": {
+                "restore-cursor": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/log-update/node_modules/mimic-fn": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+            "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/log-update/node_modules/onetime": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+            "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+            "dev": true,
+            "dependencies": {
+                "mimic-fn": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/log-update/node_modules/restore-cursor": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+            "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+            "dev": true,
+            "dependencies": {
+                "onetime": "^2.0.0",
+                "signal-exit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/log-update/node_modules/string-width": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+            "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+            "dev": true,
+            "dependencies": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/log-update/node_modules/strip-ansi": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/log-update/node_modules/wrap-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
+            "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
+            "dev": true,
+            "dependencies": {
+                "string-width": "^2.1.1",
+                "strip-ansi": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/logform": {
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/logform/-/logform-2.4.0.tgz",
@@ -6326,6 +9171,48 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
             "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+        },
+        "node_modules/loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "dev": true,
+            "dependencies": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            },
+            "bin": {
+                "loose-envify": "cli.js"
+            }
+        },
+        "node_modules/lower-case": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+            "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/lower-case-first": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-2.0.2.tgz",
+            "integrity": "sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/lower-case-first/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
+        "node_modules/lower-case/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
         },
         "node_modules/lowercase-keys": {
             "version": "1.0.1",
@@ -6417,6 +9304,15 @@
                 "tmpl": "1.0.5"
             }
         },
+        "node_modules/map-cache": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+            "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/match-stream": {
             "version": "0.0.2",
             "resolved": "https://registry.npmjs.org/match-stream/-/match-stream-0.0.2.tgz",
@@ -6477,6 +9373,23 @@
             "dev": true,
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/meros": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/meros/-/meros-1.1.4.tgz",
+            "integrity": "sha512-E9ZXfK9iQfG9s73ars9qvvvbSIkJZF5yOo9j4tcwM5tN8mUKfj/EKN5PzOr3ZH0y5wL7dLAHw3RVEfpQV9Q7VQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "peerDependencies": {
+                "@types/node": ">=12"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
             }
         },
         "node_modules/methods": {
@@ -6625,6 +9538,41 @@
             "resolved": "https://registry.npmjs.org/netrc/-/netrc-0.1.4.tgz",
             "integrity": "sha1-a+lPysqNd63gqWcNxGCRTJRHJEQ=",
             "dev": true
+        },
+        "node_modules/no-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+            "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+            "dev": true,
+            "dependencies": {
+                "lower-case": "^2.0.2",
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/no-case/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
+        "node_modules/node-domexception": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/jimmywarting"
+                },
+                {
+                    "type": "github",
+                    "url": "https://paypal.me/jimmywarting"
+                }
+            ],
+            "engines": {
+                "node": ">=10.5.0"
+            }
         },
         "node_modules/node-fetch": {
             "version": "2.6.7",
@@ -6835,6 +9783,21 @@
                 "node": ">=8"
             }
         },
+        "node_modules/nullthrows": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
+            "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
+            "dev": true
+        },
+        "node_modules/number-is-nan": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/nwsapi": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
@@ -6870,6 +9833,33 @@
             "version": "1.11.0",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
             "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/object.assign": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+            "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.0",
+                "define-properties": "^1.1.3",
+                "has-symbols": "^1.0.1",
+                "object-keys": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -6931,6 +9921,40 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/ora": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+            "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+            "dev": true,
+            "dependencies": {
+                "bl": "^4.1.0",
+                "chalk": "^4.1.0",
+                "cli-cursor": "^3.1.0",
+                "cli-spinners": "^2.5.0",
+                "is-interactive": "^1.0.0",
+                "is-unicode-supported": "^0.1.0",
+                "log-symbols": "^4.1.0",
+                "strip-ansi": "^6.0.0",
+                "wcwidth": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ora/node_modules/bl": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+            "dev": true,
+            "dependencies": {
+                "buffer": "^5.5.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0"
             }
         },
         "node_modules/os-tmpdir": {
@@ -7009,6 +10033,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/p-map": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+            "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/p-timeout": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
@@ -7059,6 +10092,22 @@
             "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
             "dev": true
         },
+        "node_modules/param-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+            "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+            "dev": true,
+            "dependencies": {
+                "dot-case": "^3.0.4",
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/param-case/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
         "node_modules/parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7069,6 +10118,20 @@
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/parse-filepath": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
+            "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
+            "dev": true,
+            "dependencies": {
+                "is-absolute": "^1.0.0",
+                "map-cache": "^0.2.0",
+                "path-root": "^0.1.1"
+            },
+            "engines": {
+                "node": ">=0.8"
             }
         },
         "node_modules/parse-json": {
@@ -7103,6 +10166,38 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/pascal-case": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+            "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+            "dev": true,
+            "dependencies": {
+                "no-case": "^3.0.4",
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/pascal-case/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
+        "node_modules/path-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+            "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+            "dev": true,
+            "dependencies": {
+                "dot-case": "^3.0.4",
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/path-case/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
         "node_modules/path-exists": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -7134,6 +10229,27 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+        },
+        "node_modules/path-root": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+            "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
+            "dev": true,
+            "dependencies": {
+                "path-root-regex": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/path-root-regex": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+            "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/path-to-regexp": {
             "version": "0.1.7",
@@ -7267,6 +10383,15 @@
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "dev": true
+        },
+        "node_modules/promise": {
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+            "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+            "dev": true,
+            "dependencies": {
+                "asap": "~2.0.3"
+            }
         },
         "node_modules/promise-throttle": {
             "version": "1.1.2",
@@ -7646,6 +10771,144 @@
                 "node": ">=8"
             }
         },
+        "node_modules/relay-compiler": {
+            "version": "12.0.0",
+            "resolved": "https://registry.npmjs.org/relay-compiler/-/relay-compiler-12.0.0.tgz",
+            "integrity": "sha512-SWqeSQZ+AMU/Cr7iZsHi1e78Z7oh00I5SvR092iCJq79aupqJ6Ds+I1Pz/Vzo5uY5PY0jvC4rBJXzlIN5g9boQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/core": "^7.14.0",
+                "@babel/generator": "^7.14.0",
+                "@babel/parser": "^7.14.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.14.0",
+                "@babel/types": "^7.0.0",
+                "babel-preset-fbjs": "^3.4.0",
+                "chalk": "^4.0.0",
+                "fb-watchman": "^2.0.0",
+                "fbjs": "^3.0.0",
+                "glob": "^7.1.1",
+                "immutable": "~3.7.6",
+                "invariant": "^2.2.4",
+                "nullthrows": "^1.1.1",
+                "relay-runtime": "12.0.0",
+                "signedsource": "^1.0.0",
+                "yargs": "^15.3.1"
+            },
+            "bin": {
+                "relay-compiler": "bin/relay-compiler"
+            },
+            "peerDependencies": {
+                "graphql": "^15.0.0"
+            }
+        },
+        "node_modules/relay-compiler/node_modules/cliui": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+            "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+            "dev": true,
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^6.2.0"
+            }
+        },
+        "node_modules/relay-compiler/node_modules/wrap-ansi": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+            "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/relay-compiler/node_modules/y18n": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+            "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+            "dev": true
+        },
+        "node_modules/relay-compiler/node_modules/yargs": {
+            "version": "15.4.1",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+            "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+            "dev": true,
+            "dependencies": {
+                "cliui": "^6.0.0",
+                "decamelize": "^1.2.0",
+                "find-up": "^4.1.0",
+                "get-caller-file": "^2.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^2.0.0",
+                "set-blocking": "^2.0.0",
+                "string-width": "^4.2.0",
+                "which-module": "^2.0.0",
+                "y18n": "^4.0.0",
+                "yargs-parser": "^18.1.2"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/relay-compiler/node_modules/yargs-parser": {
+            "version": "18.1.3",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+            "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+            "dev": true,
+            "dependencies": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/relay-runtime": {
+            "version": "12.0.0",
+            "resolved": "https://registry.npmjs.org/relay-runtime/-/relay-runtime-12.0.0.tgz",
+            "integrity": "sha512-QU6JKr1tMsry22DXNy9Whsq5rmvwr3LSZiiWV/9+DFpuTWvp+WFhobWMc8TC4OjKFfNhEZy7mOiqUAn5atQtug==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.0.0",
+                "fbjs": "^3.0.0",
+                "invariant": "^2.2.4"
+            }
+        },
+        "node_modules/remedial": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/remedial/-/remedial-1.0.8.tgz",
+            "integrity": "sha512-/62tYiOe6DzS5BqVsNpH/nkGlX45C/Sp6V+NtiN6JQNS1Viay7cWkazmRkrQrdFj2eshDe96SIQNIoMxqhzBOg==",
+            "dev": true,
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/remove-trailing-separator": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+            "dev": true
+        },
+        "node_modules/remove-trailing-spaces": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/remove-trailing-spaces/-/remove-trailing-spaces-1.0.8.tgz",
+            "integrity": "sha512-O3vsMYfWighyFbTd8hk8VaSj9UAGENxAtX+//ugIst2RMk5e03h6RoIS+0ylsFxY1gvmPuAY/PO4It+gPEeySA==",
+            "dev": true
+        },
+        "node_modules/replaceall": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/replaceall/-/replaceall-0.1.6.tgz",
+            "integrity": "sha1-gdgax663LX9cSUKt8ml6MiBojY4=",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.8.x"
+            }
+        },
         "node_modules/req-all": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/req-all/-/req-all-0.1.0.tgz",
@@ -7751,6 +11014,12 @@
                 "resolve": "^1.12.0"
             }
         },
+        "node_modules/require-main-filename": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+            "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+            "dev": true
+        },
         "node_modules/resolve": {
             "version": "1.20.0",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
@@ -7811,6 +11080,19 @@
                 "lowercase-keys": "^1.0.0"
             }
         },
+        "node_modules/restore-cursor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+            "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+            "dev": true,
+            "dependencies": {
+                "onetime": "^5.1.0",
+                "signal-exit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/retry-request": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.2.2.tgz",
@@ -7848,6 +11130,15 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/run-async": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+            "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
         "node_modules/run-parallel": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -7870,6 +11161,21 @@
             "dependencies": {
                 "queue-microtask": "^1.2.2"
             }
+        },
+        "node_modules/rxjs": {
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.4.tgz",
+            "integrity": "sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.1.0"
+            }
+        },
+        "node_modules/rxjs/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
         },
         "node_modules/safe-buffer": {
             "version": "5.1.2",
@@ -7900,6 +11206,12 @@
             "engines": {
                 "node": ">=10"
             }
+        },
+        "node_modules/scuid": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/scuid/-/scuid-1.1.0.tgz",
+            "integrity": "sha512-MuCAyrGZcTLfQoH2XoBlQ8C6bzwN88XT/0slOGz0pn8+gIP85BOAfYa44ZXQUTOwRwPU0QvgU+V+OSajl/59Xg==",
+            "dev": true
         },
         "node_modules/semver": {
             "version": "7.3.5",
@@ -7977,6 +11289,23 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
+        "node_modules/sentence-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+            "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+            "dev": true,
+            "dependencies": {
+                "no-case": "^3.0.4",
+                "tslib": "^2.0.3",
+                "upper-case-first": "^2.0.2"
+            }
+        },
+        "node_modules/sentence-case/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
         "node_modules/serve-static": {
             "version": "1.14.2",
             "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.2.tgz",
@@ -7990,6 +11319,12 @@
             "engines": {
                 "node": ">= 0.8.0"
             }
+        },
+        "node_modules/set-blocking": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+            "dev": true
         },
         "node_modules/set-immediate-shim": {
             "version": "1.0.1",
@@ -8056,6 +11391,12 @@
             "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
             "dev": true
         },
+        "node_modules/signedsource": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/signedsource/-/signedsource-1.0.0.tgz",
+            "integrity": "sha1-HdrOSYF5j5O9gzlzgD2A1S6TrWo=",
+            "dev": true
+        },
         "node_modules/simple-swizzle": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -8077,6 +11418,15 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/slice-ansi": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+            "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/slice-stream": {
@@ -8112,6 +11462,22 @@
             "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
             "dev": true
         },
+        "node_modules/snake-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+            "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+            "dev": true,
+            "dependencies": {
+                "dot-case": "^3.0.4",
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/snake-case/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
         "node_modules/source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -8128,6 +11494,21 @@
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
             }
+        },
+        "node_modules/sponge-case": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-1.0.1.tgz",
+            "integrity": "sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/sponge-case/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
         },
         "node_modules/sprintf-js": {
             "version": "1.0.3",
@@ -8237,6 +11618,12 @@
                 }
             ]
         },
+        "node_modules/string-env-interpolation": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/string-env-interpolation/-/string-env-interpolation-1.0.1.tgz",
+            "integrity": "sha512-78lwMoCcn0nNu8LszbP1UA7g55OeE4v7rCeWnM5B453rnNr4aq+5it3FEYtZrSEiMvHZOZ9Jlqb0OD0M2VInqg==",
+            "dev": true
+        },
         "node_modules/string-length": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -8309,6 +11696,22 @@
             "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
             "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls="
         },
+        "node_modules/subscriptions-transport-ws": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.11.0.tgz",
+            "integrity": "sha512-8D4C6DIH5tGiAIpp5I0wD/xRlNiZAPGHygzCe7VzyzUoxHtawzjNAY9SUTXU05/EY2NMY9/9GF0ycizkXr1CWQ==",
+            "dev": true,
+            "dependencies": {
+                "backo2": "^1.0.2",
+                "eventemitter3": "^3.1.0",
+                "iterall": "^1.2.1",
+                "symbol-observable": "^1.0.4",
+                "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^15.7.2 || ^16.0.0"
+            }
+        },
         "node_modules/supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -8334,11 +11737,48 @@
                 "node": ">=8"
             }
         },
+        "node_modules/swap-case": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-2.0.2.tgz",
+            "integrity": "sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/swap-case/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
+        "node_modules/symbol-observable": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+            "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/symbol-tree": {
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true
+        },
+        "node_modules/sync-fetch": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/sync-fetch/-/sync-fetch-0.3.1.tgz",
+            "integrity": "sha512-xj5qiCDap/03kpci5a+qc5wSJjc8ZSixgG2EUmH1B8Ea2sfWclQA7eH40hiHPCtkCn6MCk4Wb+dqcXdCy2PP3g==",
+            "dev": true,
+            "dependencies": {
+                "buffer": "^5.7.0",
+                "node-fetch": "^2.6.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/tar-fs": {
             "version": "1.16.3",
@@ -8487,6 +11927,12 @@
             "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
             "dev": true
         },
+        "node_modules/through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
+        },
         "node_modules/timezone-support": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/timezone-support/-/timezone-support-2.0.2.tgz",
@@ -8500,6 +11946,21 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/title-case": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/title-case/-/title-case-3.0.3.tgz",
+            "integrity": "sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/title-case/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
         },
         "node_modules/tmp": {
             "version": "0.0.27",
@@ -8658,6 +12119,12 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/ts-log": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/ts-log/-/ts-log-2.2.4.tgz",
+            "integrity": "sha512-DEQrfv6l7IvN2jlzc/VTdZJYsWUnQNCsueYjMkC/iXoEoi5fNan6MjeDqkvhfzbmHgdz9UxDUluX3V5HdjTydQ==",
+            "dev": true
         },
         "node_modules/ts-node": {
             "version": "10.5.0",
@@ -8873,6 +12340,34 @@
                 "node": ">=4.2.0"
             }
         },
+        "node_modules/ua-parser-js": {
+            "version": "0.7.31",
+            "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
+            "integrity": "sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/ua-parser-js"
+                },
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/faisalman"
+                }
+            ],
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/unc-path-regex": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+            "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/undefsafe": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
@@ -8884,6 +12379,15 @@
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
             "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
             "dev": true
+        },
+        "node_modules/undici": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-4.14.1.tgz",
+            "integrity": "sha512-WJ+g+XqiZcATcBaUeluCajqy4pEDcQfK1vy+Fo+bC4/mqXI9IIQD/XWHLS70fkGUT6P52Drm7IFslO651OdLPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=12.18"
+            }
         },
         "node_modules/unique-string": {
             "version": "2.0.0",
@@ -8904,6 +12408,30 @@
             "dev": true,
             "engines": {
                 "node": ">= 4.0.0"
+            }
+        },
+        "node_modules/unixify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz",
+            "integrity": "sha1-OmQcjC/7zk2mg6XHDwOkYpQMIJA=",
+            "dev": true,
+            "dependencies": {
+                "normalize-path": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/unixify/node_modules/normalize-path": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+            "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+            "dev": true,
+            "dependencies": {
+                "remove-trailing-separator": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/unpipe": {
@@ -8941,6 +12469,36 @@
             "funding": {
                 "url": "https://github.com/yeoman/update-notifier?sponsor=1"
             }
+        },
+        "node_modules/upper-case": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+            "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/upper-case-first": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+            "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/upper-case-first/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
+        },
+        "node_modules/upper-case/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
         },
         "node_modules/uri-js": {
             "version": "4.4.1",
@@ -9019,6 +12577,21 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/valid-url": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+            "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA=",
+            "dev": true
+        },
+        "node_modules/value-or-promise": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.11.tgz",
+            "integrity": "sha512-41BrgH+dIbCFXClcSapVs5M6GkENd3gQOJpEfPDNa71LsUGMXDL0jMWpI/Rh7WhX+Aalfz2TTS3Zt5pUsbnhLg==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/vary": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -9071,6 +12644,24 @@
                 "makeerror": "1.0.12"
             }
         },
+        "node_modules/wcwidth": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+            "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+            "dev": true,
+            "dependencies": {
+                "defaults": "^1.0.3"
+            }
+        },
+        "node_modules/web-streams-polyfill": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
+            "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==",
+            "dev": true,
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/webidl-conversions": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
@@ -9088,6 +12679,12 @@
             "dependencies": {
                 "iconv-lite": "0.4.24"
             }
+        },
+        "node_modules/whatwg-fetch": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+            "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
+            "dev": true
         },
         "node_modules/whatwg-mimetype": {
             "version": "2.3.0",
@@ -9123,6 +12720,12 @@
             "engines": {
                 "node": ">= 8"
             }
+        },
+        "node_modules/which-module": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+            "dev": true
         },
         "node_modules/widest-line": {
             "version": "3.1.0",
@@ -9280,6 +12883,21 @@
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
+        "node_modules/yaml": {
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+            "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/yaml-ast-parser": {
+            "version": "0.0.43",
+            "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
+            "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
+            "dev": true
+        },
         "node_modules/yargs": {
             "version": "16.2.0",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -9313,6 +12931,18 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/yocto-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         }
     },
     "dependencies": {
@@ -9326,9 +12956,9 @@
             }
         },
         "@babel/compat-data": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.0.tgz",
-            "integrity": "sha512-DGjt2QZse5SGd9nfOSqO4WLJ8NN/oHkijbXbPrxuoJO3oIPJL3TciZs9FX+cOHNiY9E9l0opL8g7BmLe3T+9ew==",
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.0.tgz",
+            "integrity": "sha512-392byTlpGWXMv4FbyWw3sAZ/FrW/DrwqLGXpy0mbyNe9Taqv1mg9yON5/o0cnr8XYCkFTZbC1eV+c+LAROgrng==",
             "dev": true
         },
         "@babel/core": {
@@ -9369,12 +12999,12 @@
             }
         },
         "@babel/generator": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
-            "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
+            "version": "7.17.3",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.3.tgz",
+            "integrity": "sha512-+R6Dctil/MgUsZsZAkYgK+ADNSZzJRRy0TvY65T71z/CR854xHQ1EweBYXdfT+HNeN7w0cSJJEzgxZMv40pxsg==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.16.0",
+                "@babel/types": "^7.17.0",
                 "jsesc": "^2.5.1",
                 "source-map": "^0.5.0"
             },
@@ -9387,15 +13017,24 @@
                 }
             }
         },
-        "@babel/helper-compilation-targets": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.0.tgz",
-            "integrity": "sha512-S7iaOT1SYlqK0sQaCi21RX4+13hmdmnxIEAnQUB/eh7GeAnRjOUgTYpLkUOiRXzD+yog1JxP0qyAQZ7ZxVxLVg==",
+        "@babel/helper-annotate-as-pure": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz",
+            "integrity": "sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==",
             "dev": true,
             "requires": {
-                "@babel/compat-data": "^7.16.0",
-                "@babel/helper-validator-option": "^7.14.5",
-                "browserslist": "^4.16.6",
+                "@babel/types": "^7.16.7"
+            }
+        },
+        "@babel/helper-compilation-targets": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.7.tgz",
+            "integrity": "sha512-mGojBwIWcwGD6rfqgRXVlVYmPAv7eOpIemUG3dGnDdCY4Pae70ROij3XmfrH6Fa1h1aiDylpglbZyktfzyo/hA==",
+            "dev": true,
+            "requires": {
+                "@babel/compat-data": "^7.16.4",
+                "@babel/helper-validator-option": "^7.16.7",
+                "browserslist": "^4.17.5",
                 "semver": "^6.3.0"
             },
             "dependencies": {
@@ -9407,76 +13046,100 @@
                 }
             }
         },
-        "@babel/helper-function-name": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
-            "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
+        "@babel/helper-create-class-features-plugin": {
+            "version": "7.17.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.17.6.tgz",
+            "integrity": "sha512-SogLLSxXm2OkBbSsHZMM4tUi8fUzjs63AT/d0YQIzr6GSd8Hxsbk2KYDX0k0DweAzGMj/YWeiCsorIdtdcW8Eg==",
             "dev": true,
             "requires": {
-                "@babel/helper-get-function-arity": "^7.16.0",
-                "@babel/template": "^7.16.0",
-                "@babel/types": "^7.16.0"
+                "@babel/helper-annotate-as-pure": "^7.16.7",
+                "@babel/helper-environment-visitor": "^7.16.7",
+                "@babel/helper-function-name": "^7.16.7",
+                "@babel/helper-member-expression-to-functions": "^7.16.7",
+                "@babel/helper-optimise-call-expression": "^7.16.7",
+                "@babel/helper-replace-supers": "^7.16.7",
+                "@babel/helper-split-export-declaration": "^7.16.7"
+            }
+        },
+        "@babel/helper-environment-visitor": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz",
+            "integrity": "sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.16.7"
+            }
+        },
+        "@babel/helper-function-name": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
+            "integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-get-function-arity": "^7.16.7",
+                "@babel/template": "^7.16.7",
+                "@babel/types": "^7.16.7"
             }
         },
         "@babel/helper-get-function-arity": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
-            "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
+            "integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.16.0"
+                "@babel/types": "^7.16.7"
             }
         },
         "@babel/helper-hoist-variables": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
-            "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
+            "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.16.0"
+                "@babel/types": "^7.16.7"
             }
         },
         "@babel/helper-member-expression-to-functions": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.0.tgz",
-            "integrity": "sha512-bsjlBFPuWT6IWhl28EdrQ+gTvSvj5tqVP5Xeftp07SEuz5pLnsXZuDkDD3Rfcxy0IsHmbZ+7B2/9SHzxO0T+sQ==",
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.7.tgz",
+            "integrity": "sha512-VtJ/65tYiU/6AbMTDwyoXGPKHgTsfRarivm+YbB5uAzKUyuPjgZSgAFeG87FCigc7KNHu2Pegh1XIT3lXjvz3Q==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.16.0"
+                "@babel/types": "^7.16.7"
             }
         },
         "@babel/helper-module-imports": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz",
-            "integrity": "sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==",
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
+            "integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.16.0"
+                "@babel/types": "^7.16.7"
             }
         },
         "@babel/helper-module-transforms": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.0.tgz",
-            "integrity": "sha512-My4cr9ATcaBbmaEa8M0dZNA74cfI6gitvUAskgDtAFmAqyFKDSHQo5YstxPbN+lzHl2D9l/YOEFqb2mtUh4gfA==",
+            "version": "7.17.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.6.tgz",
+            "integrity": "sha512-2ULmRdqoOMpdvkbT8jONrZML/XALfzxlb052bldftkicAUy8AxSCkD5trDPQcwHNmolcl7wP6ehNqMlyUw6AaA==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-imports": "^7.16.0",
-                "@babel/helper-replace-supers": "^7.16.0",
-                "@babel/helper-simple-access": "^7.16.0",
-                "@babel/helper-split-export-declaration": "^7.16.0",
-                "@babel/helper-validator-identifier": "^7.15.7",
-                "@babel/template": "^7.16.0",
-                "@babel/traverse": "^7.16.0",
-                "@babel/types": "^7.16.0"
+                "@babel/helper-environment-visitor": "^7.16.7",
+                "@babel/helper-module-imports": "^7.16.7",
+                "@babel/helper-simple-access": "^7.16.7",
+                "@babel/helper-split-export-declaration": "^7.16.7",
+                "@babel/helper-validator-identifier": "^7.16.7",
+                "@babel/template": "^7.16.7",
+                "@babel/traverse": "^7.17.3",
+                "@babel/types": "^7.17.0"
             }
         },
         "@babel/helper-optimise-call-expression": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.0.tgz",
-            "integrity": "sha512-SuI467Gi2V8fkofm2JPnZzB/SUuXoJA5zXe/xzyPP2M04686RzFKFHPK6HDVN6JvWBIEW8tt9hPR7fXdn2Lgpw==",
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.7.tgz",
+            "integrity": "sha512-EtgBhg7rd/JcnpZFXpBy0ze1YRfdm7BnBX4uKMBd3ixa3RGAE002JZB66FJyNH7g0F38U05pXmA5P8cBh7z+1w==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.16.0"
+                "@babel/types": "^7.16.7"
             }
         },
         "@babel/helper-plugin-utils": {
@@ -9486,33 +13149,43 @@
             "dev": true
         },
         "@babel/helper-replace-supers": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.16.0.tgz",
-            "integrity": "sha512-TQxuQfSCdoha7cpRNJvfaYxxxzmbxXw/+6cS7V02eeDYyhxderSoMVALvwupA54/pZcOTtVeJ0xccp1nGWladA==",
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.16.7.tgz",
+            "integrity": "sha512-y9vsWilTNaVnVh6xiJfABzsNpgDPKev9HnAgz6Gb1p6UUwf9NepdlsV7VXGCftJM+jqD5f7JIEubcpLjZj5dBw==",
             "dev": true,
             "requires": {
-                "@babel/helper-member-expression-to-functions": "^7.16.0",
-                "@babel/helper-optimise-call-expression": "^7.16.0",
-                "@babel/traverse": "^7.16.0",
-                "@babel/types": "^7.16.0"
+                "@babel/helper-environment-visitor": "^7.16.7",
+                "@babel/helper-member-expression-to-functions": "^7.16.7",
+                "@babel/helper-optimise-call-expression": "^7.16.7",
+                "@babel/traverse": "^7.16.7",
+                "@babel/types": "^7.16.7"
             }
         },
         "@babel/helper-simple-access": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.7.tgz",
+            "integrity": "sha512-ZIzHVyoeLMvXMN/vok/a4LWRy8G2v205mNP0XOuf9XRLyX5/u9CnVulUtDgUTama3lT+bf/UqucuZjqiGuTS1g==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.16.7"
+            }
+        },
+        "@babel/helper-skip-transparent-expression-wrappers": {
             "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.0.tgz",
-            "integrity": "sha512-o1rjBT/gppAqKsYfUdfHq5Rk03lMQrkPHG1OWzHWpLgVXRH4HnMM9Et9CVdIqwkCQlobnGHEJMsgWP/jE1zUiw==",
+            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.16.0.tgz",
+            "integrity": "sha512-+il1gTy0oHwUsBQZyJvukbB4vPMdcYBrFHa0Uc4AizLxbq6BOYC51Rv4tWocX9BLBDLZ4kc6qUFpQ6HRgL+3zw==",
             "dev": true,
             "requires": {
                 "@babel/types": "^7.16.0"
             }
         },
         "@babel/helper-split-export-declaration": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
-            "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
+            "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.16.0"
+                "@babel/types": "^7.16.7"
             }
         },
         "@babel/helper-validator-identifier": {
@@ -9522,9 +13195,9 @@
             "dev": true
         },
         "@babel/helper-validator-option": {
-            "version": "7.14.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
-            "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
+            "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
             "dev": true
         },
         "@babel/helpers": {
@@ -9608,10 +13281,33 @@
             }
         },
         "@babel/parser": {
-            "version": "7.16.2",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.2.tgz",
-            "integrity": "sha512-RUVpT0G2h6rOZwqLDTrKk7ksNv7YpAilTnYe1/Q+eDjxEceRMKVWbCsX7t8h6C1qCFi/1Y8WZjcEPBAFG27GPw==",
+            "version": "7.17.3",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.3.tgz",
+            "integrity": "sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA==",
             "dev": true
+        },
+        "@babel/plugin-proposal-class-properties": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.16.7.tgz",
+            "integrity": "sha512-IobU0Xme31ewjYOShSIqd/ZGM/r/cuOz2z0MDbNrhF5FW+ZVgi0f2lyeoj9KFPDOAqsYxmLWZte1WOwlvY9aww==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-create-class-features-plugin": "^7.16.7",
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-proposal-object-rest-spread": {
+            "version": "7.17.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.17.3.tgz",
+            "integrity": "sha512-yuL5iQA/TbZn+RGAfxQXfi7CNLmKi1f8zInn4IgobuCWcAb7i+zj4TYzQ9l8cEzVyJ89PDGuqxK1xZpUDISesw==",
+            "dev": true,
+            "requires": {
+                "@babel/compat-data": "^7.17.0",
+                "@babel/helper-compilation-targets": "^7.16.7",
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+                "@babel/plugin-transform-parameters": "^7.16.7"
+            }
         },
         "@babel/plugin-syntax-async-generators": {
             "version": "7.8.4",
@@ -9640,6 +13336,15 @@
                 "@babel/helper-plugin-utils": "^7.12.13"
             }
         },
+        "@babel/plugin-syntax-flow": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.16.7.tgz",
+            "integrity": "sha512-UDo3YGQO0jH6ytzVwgSLv9i/CzMcUjbKenL67dTrAZPPv6GFAtDhe6jqnvmoKzC/7htNTohhos+onPtDMqJwaQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
         "@babel/plugin-syntax-import-meta": {
             "version": "7.10.4",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
@@ -9656,6 +13361,15 @@
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-jsx": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.16.7.tgz",
+            "integrity": "sha512-Esxmk7YjA8QysKeT3VhTXvF6y77f/a91SIs4pWb4H2eWGQkCKFgQaG6hdoEVZtGsrAcb2K5BW66XsOErD4WU3Q==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7"
             }
         },
         "@babel/plugin-syntax-logical-assignment-operators": {
@@ -9730,6 +13444,213 @@
                 "@babel/helper-plugin-utils": "^7.16.7"
             }
         },
+        "@babel/plugin-transform-arrow-functions": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.16.7.tgz",
+            "integrity": "sha512-9ffkFFMbvzTvv+7dTp/66xvZAWASuPD5Tl9LK3Z9vhOmANo6j94rik+5YMBt4CwHVMWLWpMsriIc2zsa3WW3xQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-block-scoped-functions": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.16.7.tgz",
+            "integrity": "sha512-JUuzlzmF40Z9cXyytcbZEZKckgrQzChbQJw/5PuEHYeqzCsvebDx0K0jWnIIVcmmDOAVctCgnYs0pMcrYj2zJg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-block-scoping": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.16.7.tgz",
+            "integrity": "sha512-ObZev2nxVAYA4bhyusELdo9hb3H+A56bxH3FZMbEImZFiEDYVHXQSJ1hQKFlDnlt8G9bBrCZ5ZpURZUrV4G5qQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-classes": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.16.7.tgz",
+            "integrity": "sha512-WY7og38SFAGYRe64BrjKf8OrE6ulEHtr5jEYaZMwox9KebgqPi67Zqz8K53EKk1fFEJgm96r32rkKZ3qA2nCWQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.16.7",
+                "@babel/helper-environment-visitor": "^7.16.7",
+                "@babel/helper-function-name": "^7.16.7",
+                "@babel/helper-optimise-call-expression": "^7.16.7",
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "@babel/helper-replace-supers": "^7.16.7",
+                "@babel/helper-split-export-declaration": "^7.16.7",
+                "globals": "^11.1.0"
+            },
+            "dependencies": {
+                "globals": {
+                    "version": "11.12.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+                    "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/plugin-transform-computed-properties": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.16.7.tgz",
+            "integrity": "sha512-gN72G9bcmenVILj//sv1zLNaPyYcOzUho2lIJBMh/iakJ9ygCo/hEF9cpGb61SCMEDxbbyBoVQxrt+bWKu5KGw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-destructuring": {
+            "version": "7.17.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.17.3.tgz",
+            "integrity": "sha512-dDFzegDYKlPqa72xIlbmSkly5MluLoaC1JswABGktyt6NTXSBcUuse/kWE/wvKFWJHPETpi158qJZFS3JmykJg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-flow-strip-types": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.16.7.tgz",
+            "integrity": "sha512-mzmCq3cNsDpZZu9FADYYyfZJIOrSONmHcop2XEKPdBNMa4PDC4eEvcOvzZaCNcjKu72v0XQlA5y1g58aLRXdYg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "@babel/plugin-syntax-flow": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-for-of": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.16.7.tgz",
+            "integrity": "sha512-/QZm9W92Ptpw7sjI9Nx1mbcsWz33+l8kuMIQnDwgQBG5s3fAfQvkRjQ7NqXhtNcKOnPkdICmUHyCaWW06HCsqg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-function-name": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.16.7.tgz",
+            "integrity": "sha512-SU/C68YVwTRxqWj5kgsbKINakGag0KTgq9f2iZEXdStoAbOzLHEBRYzImmA6yFo8YZhJVflvXmIHUO7GWHmxxA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-compilation-targets": "^7.16.7",
+                "@babel/helper-function-name": "^7.16.7",
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-literals": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.16.7.tgz",
+            "integrity": "sha512-6tH8RTpTWI0s2sV6uq3e/C9wPo4PTqqZps4uF0kzQ9/xPLFQtipynvmT1g/dOfEJ+0EQsHhkQ/zyRId8J2b8zQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-member-expression-literals": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.16.7.tgz",
+            "integrity": "sha512-mBruRMbktKQwbxaJof32LT9KLy2f3gH+27a5XSuXo6h7R3vqltl0PgZ80C8ZMKw98Bf8bqt6BEVi3svOh2PzMw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-modules-commonjs": {
+            "version": "7.16.8",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.16.8.tgz",
+            "integrity": "sha512-oflKPvsLT2+uKQopesJt3ApiaIS2HW+hzHFcwRNtyDGieAeC/dIHZX8buJQ2J2X1rxGPy4eRcUijm3qcSPjYcA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-transforms": "^7.16.7",
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "@babel/helper-simple-access": "^7.16.7",
+                "babel-plugin-dynamic-import-node": "^2.3.3"
+            }
+        },
+        "@babel/plugin-transform-object-super": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.16.7.tgz",
+            "integrity": "sha512-14J1feiQVWaGvRxj2WjyMuXS2jsBkgB3MdSN5HuC2G5nRspa5RK9COcs82Pwy5BuGcjb+fYaUj94mYcOj7rCvw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "@babel/helper-replace-supers": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-parameters": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.16.7.tgz",
+            "integrity": "sha512-AT3MufQ7zZEhU2hwOA11axBnExW0Lszu4RL/tAlUJBuNoRak+wehQW8h6KcXOcgjY42fHtDxswuMhMjFEuv/aw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-property-literals": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.16.7.tgz",
+            "integrity": "sha512-z4FGr9NMGdoIl1RqavCqGG+ZuYjfZ/hkCIeuH6Do7tXmSm0ls11nYVSJqFEUOSJbDab5wC6lRE/w6YjVcr6Hqw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-react-display-name": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.16.7.tgz",
+            "integrity": "sha512-qgIg8BcZgd0G/Cz916D5+9kqX0c7nPZyXaP8R2tLNN5tkyIZdG5fEwBrxwplzSnjC1jvQmyMNVwUCZPcbGY7Pg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-react-jsx": {
+            "version": "7.17.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.17.3.tgz",
+            "integrity": "sha512-9tjBm4O07f7mzKSIlEmPdiE6ub7kfIe6Cd+w+oQebpATfTQMAgW+YOuWxogbKVTulA+MEO7byMeIUtQ1z+z+ZQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.16.7",
+                "@babel/helper-module-imports": "^7.16.7",
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "@babel/plugin-syntax-jsx": "^7.16.7",
+                "@babel/types": "^7.17.0"
+            }
+        },
+        "@babel/plugin-transform-shorthand-properties": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.16.7.tgz",
+            "integrity": "sha512-hah2+FEnoRoATdIb05IOXf+4GzXYTq75TVhIn1PewihbpyrNWUt2JbudKQOETWw6QpLe+AIUpJ5MVLYTQbeeUg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-spread": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.16.7.tgz",
+            "integrity": "sha512-+pjJpgAngb53L0iaA5gU/1MLXJIfXcYepLgXB3esVRf4fqmj8f2cxM3/FKaHsZms08hFQJkFccEWuIpm429TXg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0"
+            }
+        },
+        "@babel/plugin-transform-template-literals": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.16.7.tgz",
+            "integrity": "sha512-VwbkDDUeenlIjmfNeDX/V0aWrQH2QiVyJtwymVQSzItFDTpxfyJh3EVaQiS0rIN/CqbLGr0VcGmuwyTdZtdIsA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
         "@babel/polyfill": {
             "version": "7.12.1",
             "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
@@ -9739,30 +13660,40 @@
                 "regenerator-runtime": "^0.13.4"
             }
         },
-        "@babel/template": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
-            "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
+        "@babel/runtime": {
+            "version": "7.17.2",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
+            "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.16.0",
-                "@babel/parser": "^7.16.0",
-                "@babel/types": "^7.16.0"
+                "regenerator-runtime": "^0.13.4"
+            }
+        },
+        "@babel/template": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
+            "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.16.7",
+                "@babel/parser": "^7.16.7",
+                "@babel/types": "^7.16.7"
             }
         },
         "@babel/traverse": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.0.tgz",
-            "integrity": "sha512-qQ84jIs1aRQxaGaxSysII9TuDaguZ5yVrEuC0BN2vcPlalwfLovVmCjbFDPECPXcYM/wLvNFfp8uDOliLxIoUQ==",
+            "version": "7.17.3",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
+            "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.16.0",
-                "@babel/generator": "^7.16.0",
-                "@babel/helper-function-name": "^7.16.0",
-                "@babel/helper-hoist-variables": "^7.16.0",
-                "@babel/helper-split-export-declaration": "^7.16.0",
-                "@babel/parser": "^7.16.0",
-                "@babel/types": "^7.16.0",
+                "@babel/code-frame": "^7.16.7",
+                "@babel/generator": "^7.17.3",
+                "@babel/helper-environment-visitor": "^7.16.7",
+                "@babel/helper-function-name": "^7.16.7",
+                "@babel/helper-hoist-variables": "^7.16.7",
+                "@babel/helper-split-export-declaration": "^7.16.7",
+                "@babel/parser": "^7.17.3",
+                "@babel/types": "^7.17.0",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
             },
@@ -9776,12 +13707,12 @@
             }
         },
         "@babel/types": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
-            "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+            "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
             "dev": true,
             "requires": {
-                "@babel/helper-validator-identifier": "^7.15.7",
+                "@babel/helper-validator-identifier": "^7.16.7",
                 "to-fast-properties": "^2.0.0"
             }
         },
@@ -9819,6 +13750,40 @@
                 "colorspace": "1.1.x",
                 "enabled": "2.0.x",
                 "kuler": "^2.0.0"
+            }
+        },
+        "@endemolshinegroup/cosmiconfig-typescript-loader": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@endemolshinegroup/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-3.0.2.tgz",
+            "integrity": "sha512-QRVtqJuS1mcT56oHpVegkKBlgtWjXw/gHNWO3eL9oyB5Sc7HBoc2OLG/nYpVfT/Jejvo3NUrD0Udk7XgoyDKkA==",
+            "dev": true,
+            "requires": {
+                "lodash.get": "^4",
+                "make-error": "^1",
+                "ts-node": "^9",
+                "tslib": "^2"
+            },
+            "dependencies": {
+                "ts-node": {
+                    "version": "9.1.1",
+                    "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+                    "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+                    "dev": true,
+                    "requires": {
+                        "arg": "^4.1.0",
+                        "create-require": "^1.1.0",
+                        "diff": "^4.0.1",
+                        "make-error": "^1.1.1",
+                        "source-map-support": "^0.5.17",
+                        "yn": "3.1.1"
+                    }
+                },
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
             }
         },
         "@entur/sdk": {
@@ -9974,6 +13939,703 @@
                 "uuid": "^8.0.0"
             }
         },
+        "@graphql-codegen/cli": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@graphql-codegen/cli/-/cli-2.4.0.tgz",
+            "integrity": "sha512-4iiHH2AxBE17lX5cFdFg6+kh7I6uKQLYG0IZRalRbW/grKL7kuVp/RDUjmVB2GNJTJEhjxYLMJFJZocUmAUBlw==",
+            "dev": true,
+            "requires": {
+                "@graphql-codegen/core": "2.4.0",
+                "@graphql-codegen/plugin-helpers": "^2.3.2",
+                "@graphql-tools/apollo-engine-loader": "^7.0.5",
+                "@graphql-tools/code-file-loader": "^7.0.6",
+                "@graphql-tools/git-loader": "^7.0.5",
+                "@graphql-tools/github-loader": "^7.0.5",
+                "@graphql-tools/graphql-file-loader": "^7.0.5",
+                "@graphql-tools/json-file-loader": "^7.1.2",
+                "@graphql-tools/load": "^7.3.0",
+                "@graphql-tools/prisma-loader": "^7.0.6",
+                "@graphql-tools/url-loader": "^7.0.11",
+                "@graphql-tools/utils": "^8.1.1",
+                "ansi-escapes": "^4.3.1",
+                "chalk": "^4.1.0",
+                "change-case-all": "1.0.14",
+                "chokidar": "^3.5.2",
+                "common-tags": "^1.8.0",
+                "cosmiconfig": "^7.0.0",
+                "debounce": "^1.2.0",
+                "dependency-graph": "^0.11.0",
+                "detect-indent": "^6.0.0",
+                "glob": "^7.1.6",
+                "globby": "^11.0.4",
+                "graphql-config": "^4.1.0",
+                "inquirer": "^8.0.0",
+                "is-glob": "^4.0.1",
+                "json-to-pretty-yaml": "^1.2.2",
+                "latest-version": "5.1.0",
+                "listr": "^0.14.3",
+                "listr-update-renderer": "^0.5.0",
+                "log-symbols": "^4.0.0",
+                "minimatch": "^3.0.4",
+                "mkdirp": "^1.0.4",
+                "string-env-interpolation": "^1.0.1",
+                "ts-log": "^2.2.3",
+                "tslib": "~2.3.0",
+                "valid-url": "^1.0.9",
+                "wrap-ansi": "^7.0.0",
+                "yaml": "^1.10.0",
+                "yargs": "^17.0.0"
+            },
+            "dependencies": {
+                "mkdirp": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+                    "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+                    "dev": true
+                },
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "17.3.1",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+                    "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^7.0.2",
+                        "escalade": "^3.1.1",
+                        "get-caller-file": "^2.0.5",
+                        "require-directory": "^2.1.1",
+                        "string-width": "^4.2.3",
+                        "y18n": "^5.0.5",
+                        "yargs-parser": "^21.0.0"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "21.0.0",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
+                    "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+                    "dev": true
+                }
+            }
+        },
+        "@graphql-codegen/core": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@graphql-codegen/core/-/core-2.4.0.tgz",
+            "integrity": "sha512-5RiYE1+07jayp/3w/bkyaCXtfKNeKmRabpPP4aRi369WeH2cH37l2K8NbhkIU+zhpnhoqMID61TO56x2fKldZQ==",
+            "dev": true,
+            "requires": {
+                "@graphql-codegen/plugin-helpers": "^2.3.2",
+                "@graphql-tools/schema": "^8.1.2",
+                "@graphql-tools/utils": "^8.1.1",
+                "tslib": "~2.3.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
+        "@graphql-codegen/plugin-helpers": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-2.4.1.tgz",
+            "integrity": "sha512-OPMma7aUnES3Dh+M0BfiNBnJLmYuH60EnbULAhufxFDn/Y2OA0Ht/LQok9beX6VN4ASZEMCOAGItJezGJr5DJw==",
+            "dev": true,
+            "requires": {
+                "@graphql-tools/utils": "^8.5.2",
+                "change-case-all": "1.0.14",
+                "common-tags": "1.8.2",
+                "import-from": "4.0.0",
+                "lodash": "~4.17.0",
+                "tslib": "~2.3.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
+        "@graphql-codegen/schema-ast": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@graphql-codegen/schema-ast/-/schema-ast-2.4.1.tgz",
+            "integrity": "sha512-bIWlKk/ShoVJfghA4Rt1OWnd34/dQmZM/vAe6fu6QKyOh44aAdqPtYQ2dbTyFXoknmu504etKJGEDllYNUJRfg==",
+            "dev": true,
+            "requires": {
+                "@graphql-codegen/plugin-helpers": "^2.3.2",
+                "@graphql-tools/utils": "^8.1.1",
+                "tslib": "~2.3.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
+        "@graphql-codegen/typescript": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-2.4.2.tgz",
+            "integrity": "sha512-8ajWidiFqF1KNAywtb/692SjwTyjzrDHo1sf2Q7Z+rh9qDEIrh83VHB8naT/1CefOvxj3MS6GbcsvJMizaE/AQ==",
+            "dev": true,
+            "requires": {
+                "@graphql-codegen/plugin-helpers": "^2.3.2",
+                "@graphql-codegen/schema-ast": "^2.4.1",
+                "@graphql-codegen/visitor-plugin-common": "2.5.2",
+                "auto-bind": "~4.0.0",
+                "tslib": "~2.3.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
+        "@graphql-codegen/typescript-graphql-files-modules": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-graphql-files-modules/-/typescript-graphql-files-modules-2.1.1.tgz",
+            "integrity": "sha512-MmLHjLoS5zrzDOtu9B4XjSs/OJr267dhRX9Wuz8jIB0azZBhJWVDw3p8O/0/Y+IbIXAbhSPlPVyaU4eWsJOgtQ==",
+            "dev": true,
+            "requires": {
+                "@graphql-codegen/plugin-helpers": "^2.3.2",
+                "tslib": "~2.3.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
+        "@graphql-codegen/typescript-operations": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-operations/-/typescript-operations-2.2.2.tgz",
+            "integrity": "sha512-J50AuTA37RYv67hP2oHbfr3iGxexTCoadQsbr5pEUGucrIupCA0hLEJH2W+9/h6YNh0UlZT3kRTJp81ARoAjOA==",
+            "dev": true,
+            "requires": {
+                "@graphql-codegen/plugin-helpers": "^2.3.2",
+                "@graphql-codegen/typescript": "^2.4.2",
+                "@graphql-codegen/visitor-plugin-common": "2.5.2",
+                "auto-bind": "~4.0.0",
+                "tslib": "~2.3.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
+        "@graphql-codegen/visitor-plugin-common": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.5.2.tgz",
+            "integrity": "sha512-qDMraPmumG+vEGAz42/asRkdgIRmQWH5HTc320UX+I6CY6eE/Ey85cgzoqeQGLV8gu4sj3UkNx/3/r79eX4u+Q==",
+            "dev": true,
+            "requires": {
+                "@graphql-codegen/plugin-helpers": "^2.3.2",
+                "@graphql-tools/optimize": "^1.0.1",
+                "@graphql-tools/relay-operation-optimizer": "^6.3.7",
+                "@graphql-tools/utils": "^8.3.0",
+                "auto-bind": "~4.0.0",
+                "change-case-all": "1.0.14",
+                "dependency-graph": "^0.11.0",
+                "graphql-tag": "^2.11.0",
+                "parse-filepath": "^1.0.2",
+                "tslib": "~2.3.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
+        "@graphql-tools/apollo-engine-loader": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/apollo-engine-loader/-/apollo-engine-loader-7.2.3.tgz",
+            "integrity": "sha512-c1AVwAoKf/dSQw6yn/OfwobybplDuAJWLvJS7K7Bm4BiFv0/YXiizPTMsYvxlJYg3uGvmA7fsoeicrzBdlwOpA==",
+            "dev": true,
+            "requires": {
+                "@graphql-tools/utils": "^8.6.2",
+                "cross-undici-fetch": "^0.1.19",
+                "sync-fetch": "0.3.1",
+                "tslib": "~2.3.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
+        "@graphql-tools/batch-execute": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.3.2.tgz",
+            "integrity": "sha512-ICWqM+MvEkIPHm18Q0cmkvm134zeQMomBKmTRxyxMNhL/ouz6Nqld52/brSlaHnzA3fczupeRJzZ0YatruGBcQ==",
+            "dev": true,
+            "requires": {
+                "@graphql-tools/utils": "^8.6.2",
+                "dataloader": "2.0.0",
+                "tslib": "~2.3.0",
+                "value-or-promise": "1.0.11"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
+        "@graphql-tools/code-file-loader": {
+            "version": "7.2.4",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-7.2.4.tgz",
+            "integrity": "sha512-KjIxYKDIbrtRGzeboYC98OnRnCvDVDC3E+suH48J4/KxweSjrG+ZpD++T/A11FdIcFb1Y5OceCw+OwjHI5OoyQ==",
+            "dev": true,
+            "requires": {
+                "@graphql-tools/graphql-tag-pluck": "^7.1.6",
+                "@graphql-tools/utils": "^8.6.2",
+                "globby": "^11.0.3",
+                "tslib": "~2.3.0",
+                "unixify": "^1.0.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
+        "@graphql-tools/delegate": {
+            "version": "8.5.1",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.5.1.tgz",
+            "integrity": "sha512-/YPmVxitt57F8sH50pnfXASzOOjEfaUDkX48eF5q6f16+JBncej2zeu+Zm2c68q8MbIxhPlEGfpd0QZeqTvAxw==",
+            "dev": true,
+            "requires": {
+                "@graphql-tools/batch-execute": "^8.3.2",
+                "@graphql-tools/schema": "^8.3.2",
+                "@graphql-tools/utils": "^8.6.2",
+                "dataloader": "2.0.0",
+                "graphql-executor": "0.0.18",
+                "tslib": "~2.3.0",
+                "value-or-promise": "1.0.11"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
+        "@graphql-tools/git-loader": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/git-loader/-/git-loader-7.1.3.tgz",
+            "integrity": "sha512-Ya0jRizD6F1hbajk2rwfqJKAp6dQRvzW1gzkOQmlNcQOTtTjWITsFtzk7fS02gZRWkfFBenlTBguGufh91I6bg==",
+            "dev": true,
+            "requires": {
+                "@graphql-tools/graphql-tag-pluck": "^7.1.6",
+                "@graphql-tools/utils": "^8.6.2",
+                "is-glob": "4.0.3",
+                "micromatch": "^4.0.4",
+                "tslib": "~2.3.0",
+                "unixify": "^1.0.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
+        "@graphql-tools/github-loader": {
+            "version": "7.2.4",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/github-loader/-/github-loader-7.2.4.tgz",
+            "integrity": "sha512-QuSN2GWgm/h3lp7o5zpi8TzHnzom4b/f5Zq4Hvprn1OsGaOviHLXQUx6AaWa07cmFvPL0se79R0sEkMZlXlpQQ==",
+            "dev": true,
+            "requires": {
+                "@graphql-tools/graphql-tag-pluck": "^7.1.6",
+                "@graphql-tools/utils": "^8.6.2",
+                "cross-undici-fetch": "^0.1.19",
+                "sync-fetch": "0.3.1",
+                "tslib": "~2.3.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
+        "@graphql-tools/graphql-file-loader": {
+            "version": "7.3.4",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.3.4.tgz",
+            "integrity": "sha512-Q0/YtDq0APR6syRclsQMNguWKRlchd8nFTOpLhfc7Xeiy21VhEEi4Ik+quRySfb7ubDfJGhiUq4MQW43FhWJvg==",
+            "dev": true,
+            "requires": {
+                "@graphql-tools/import": "^6.6.6",
+                "@graphql-tools/utils": "^8.6.2",
+                "globby": "^11.0.3",
+                "tslib": "~2.3.0",
+                "unixify": "^1.0.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
+        "@graphql-tools/graphql-tag-pluck": {
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-7.1.6.tgz",
+            "integrity": "sha512-VdubvdS8pIrAPVDq6hV7ARXz2Yh8/2153+RO6i+RJOMgyFw8wOW3jRCKE93eN+Hk2pZBC2x3kzdNeUAyVpuslg==",
+            "dev": true,
+            "requires": {
+                "@babel/parser": "^7.16.8",
+                "@babel/traverse": "^7.16.8",
+                "@babel/types": "^7.16.8",
+                "@graphql-tools/utils": "^8.6.2",
+                "tslib": "~2.3.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
+        "@graphql-tools/import": {
+            "version": "6.6.6",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.6.6.tgz",
+            "integrity": "sha512-a0aVajxqu1MsL8EwavA44Osw20lBOIhq8IM2ZIHFPP62cPAcOB26P+Sq57DHMsSyX5YQ0ab9XPM2o4e1dQhs0w==",
+            "dev": true,
+            "requires": {
+                "@graphql-tools/utils": "8.6.2",
+                "resolve-from": "5.0.0",
+                "tslib": "~2.3.0"
+            },
+            "dependencies": {
+                "resolve-from": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+                    "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+                    "dev": true
+                },
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
+        "@graphql-tools/json-file-loader": {
+            "version": "7.3.4",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.3.4.tgz",
+            "integrity": "sha512-1AROMFh8Lyorf2gTWXgVaUbU3ic84gzAgpRmJCsCla/Nnvn6JiCs4aWHsalk4ZWVXCaK04c8gk8Px1uNQUj02Q==",
+            "dev": true,
+            "requires": {
+                "@graphql-tools/utils": "^8.6.2",
+                "globby": "^11.0.3",
+                "tslib": "~2.3.0",
+                "unixify": "^1.0.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
+        "@graphql-tools/load": {
+            "version": "7.5.2",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.5.2.tgz",
+            "integrity": "sha512-URPqVP77mYxdZxT895DzrWf2C23S3yC/oAmXD4D4YlxR5eVVH/fxu0aZR78WcEKF331fWSiFwWy9j7BZWvkj7g==",
+            "dev": true,
+            "requires": {
+                "@graphql-tools/schema": "8.3.2",
+                "@graphql-tools/utils": "^8.6.2",
+                "p-limit": "3.1.0",
+                "tslib": "~2.3.0"
+            },
+            "dependencies": {
+                "p-limit": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+                    "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+                    "dev": true,
+                    "requires": {
+                        "yocto-queue": "^0.1.0"
+                    }
+                },
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
+        "@graphql-tools/merge": {
+            "version": "8.2.3",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.3.tgz",
+            "integrity": "sha512-XCSmL6/Xg8259OTWNp69B57CPWiVL69kB7pposFrufG/zaAlI9BS68dgzrxmmSqZV5ZHU4r/6Tbf6fwnEJGiSw==",
+            "dev": true,
+            "requires": {
+                "@graphql-tools/utils": "^8.6.2",
+                "tslib": "~2.3.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
+        "@graphql-tools/optimize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/optimize/-/optimize-1.2.0.tgz",
+            "integrity": "sha512-l0PTqgHeorQdeOizUor6RB49eOAng9+abSxiC5/aHRo6hMmXVaqv5eqndlmxCpx9BkgNb3URQbK+ZZHVktkP/g==",
+            "dev": true,
+            "requires": {
+                "tslib": "~2.3.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
+        "@graphql-tools/prisma-loader": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/prisma-loader/-/prisma-loader-7.1.2.tgz",
+            "integrity": "sha512-AK/MIEaCDtcV41JTtdTmRBV8I6DM102FWJDbb3rTOVtIYSjU62G23yrPca8aMVcnIneQQNJ7MKYO18agCYXzqw==",
+            "dev": true,
+            "requires": {
+                "@graphql-tools/url-loader": "^7.7.2",
+                "@graphql-tools/utils": "^8.6.2",
+                "@types/js-yaml": "^4.0.0",
+                "@types/json-stable-stringify": "^1.0.32",
+                "@types/jsonwebtoken": "^8.5.0",
+                "chalk": "^4.1.0",
+                "debug": "^4.3.1",
+                "dotenv": "^16.0.0",
+                "graphql-request": "^4.0.0",
+                "http-proxy-agent": "^5.0.0",
+                "https-proxy-agent": "^5.0.0",
+                "isomorphic-fetch": "^3.0.0",
+                "js-yaml": "^4.0.0",
+                "json-stable-stringify": "^1.0.1",
+                "jsonwebtoken": "^8.5.1",
+                "lodash": "^4.17.20",
+                "replaceall": "^0.1.6",
+                "scuid": "^1.1.0",
+                "tslib": "~2.3.0",
+                "yaml-ast-parser": "^0.0.43"
+            },
+            "dependencies": {
+                "@tootallnate/once": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+                    "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+                    "dev": true
+                },
+                "extract-files": {
+                    "version": "9.0.0",
+                    "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-9.0.0.tgz",
+                    "integrity": "sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==",
+                    "dev": true
+                },
+                "graphql-request": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-4.0.0.tgz",
+                    "integrity": "sha512-cdqQLCXlBGkaLdkLYRl4LtkwaZU6TfpE7/tnUQFl3wXfUPWN74Ov+Q61VuIh+AltS789YfGB6whghmCmeXLvTw==",
+                    "dev": true,
+                    "requires": {
+                        "cross-fetch": "^3.0.6",
+                        "extract-files": "^9.0.0",
+                        "form-data": "^3.0.0"
+                    }
+                },
+                "http-proxy-agent": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+                    "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+                    "dev": true,
+                    "requires": {
+                        "@tootallnate/once": "2",
+                        "agent-base": "6",
+                        "debug": "4"
+                    }
+                },
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
+        "@graphql-tools/relay-operation-optimizer": {
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.4.2.tgz",
+            "integrity": "sha512-pc/cliYO0veVbMyM5H54lZzQh+9SxnjawqR623rc+jPuY9JUQcuIKkZzM1+E5blbtr4dvh7Bi4uzf3rJ0sxG0Q==",
+            "dev": true,
+            "requires": {
+                "@graphql-tools/utils": "^8.6.2",
+                "relay-compiler": "12.0.0",
+                "tslib": "~2.3.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
+        "@graphql-tools/schema": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.3.2.tgz",
+            "integrity": "sha512-77feSmIuHdoxMXRbRyxE8rEziKesd/AcqKV6fmxe7Zt+PgIQITxNDew2XJJg7qFTMNM43W77Ia6njUSBxNOkwg==",
+            "dev": true,
+            "requires": {
+                "@graphql-tools/merge": "^8.2.3",
+                "@graphql-tools/utils": "^8.6.2",
+                "tslib": "~2.3.0",
+                "value-or-promise": "1.0.11"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
+        "@graphql-tools/url-loader": {
+            "version": "7.7.2",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.7.2.tgz",
+            "integrity": "sha512-7qDLs7zvFg3shr6UDvArYTlhezjsulIGt7bUIve3nZZDgs/x8EAKeod4/+pt1ZUYq19aSMt19N1Een0F+xWWsA==",
+            "dev": true,
+            "requires": {
+                "@graphql-tools/delegate": "^8.5.1",
+                "@graphql-tools/utils": "^8.6.2",
+                "@graphql-tools/wrap": "^8.4.2",
+                "@n1ru4l/graphql-live-query": "^0.9.0",
+                "@types/websocket": "^1.0.4",
+                "@types/ws": "^8.0.0",
+                "cross-undici-fetch": "^0.1.19",
+                "dset": "^3.1.0",
+                "extract-files": "^11.0.0",
+                "graphql-sse": "^1.0.1",
+                "graphql-ws": "^5.4.1",
+                "isomorphic-ws": "^4.0.1",
+                "meros": "^1.1.4",
+                "subscriptions-transport-ws": "^0.11.0",
+                "sync-fetch": "^0.3.1",
+                "tslib": "^2.3.0",
+                "valid-url": "^1.0.9",
+                "value-or-promise": "^1.0.11",
+                "ws": "^8.3.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                },
+                "ws": {
+                    "version": "8.5.0",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+                    "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+                    "dev": true,
+                    "requires": {}
+                }
+            }
+        },
+        "@graphql-tools/utils": {
+            "version": "8.6.2",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
+            "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+            "dev": true,
+            "requires": {
+                "tslib": "~2.3.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
+        "@graphql-tools/wrap": {
+            "version": "8.4.2",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.4.2.tgz",
+            "integrity": "sha512-U6vpfOhp+uyTNsDi1wbk0dpCn6oJ3CmRS2EUpyuzHQDC7YQgAElxn5Wl/eDsKmhJGzGDODKY9M6yHAEH/tRrPQ==",
+            "dev": true,
+            "requires": {
+                "@graphql-tools/delegate": "^8.5.1",
+                "@graphql-tools/schema": "^8.3.2",
+                "@graphql-tools/utils": "^8.6.2",
+                "tslib": "~2.3.0",
+                "value-or-promise": "1.0.11"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
         "@grpc/grpc-js": {
             "version": "1.5.5",
             "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.5.5.tgz",
@@ -10010,6 +14672,12 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
             "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+            "dev": true
+        },
+        "@iarna/toml": {
+            "version": "2.2.5",
+            "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+            "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
             "dev": true
         },
         "@istanbuljs/load-nyc-config": {
@@ -10249,6 +14917,13 @@
                 "chalk": "^4.0.0"
             }
         },
+        "@n1ru4l/graphql-live-query": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/@n1ru4l/graphql-live-query/-/graphql-live-query-0.9.0.tgz",
+            "integrity": "sha512-BTpWy1e+FxN82RnLz4x1+JcEewVdfmUhV1C6/XYD5AjS7PQp9QFF7K8bCD6gzPTr2l+prvqOyVueQhFJxB1vfg==",
+            "dev": true,
+            "requires": {}
+        },
         "@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -10355,6 +15030,15 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
             "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+        },
+        "@samverschueren/stream-to-observable": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz",
+            "integrity": "sha512-c/qwwcHyafOQuVQJj0IlBjf5yYgBI7YPJ77k4fOJYesb41jio65eaJODRUmfYKhTOFBrIZ66kgvGPlNbjuoRdQ==",
+            "dev": true,
+            "requires": {
+                "any-observable": "^0.3.0"
+            }
         },
         "@sindresorhus/is": {
             "version": "0.14.0",
@@ -10580,6 +15264,15 @@
                 "@types/node": "*"
             }
         },
+        "@types/graphql": {
+            "version": "14.5.0",
+            "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-14.5.0.tgz",
+            "integrity": "sha512-MOkzsEp1Jk5bXuAsHsUi6BVv0zCO+7/2PTiZMXWDSsMXvNU6w/PLMQT2vHn8hy2i0JqojPz1Sz6rsFjHtsU0lA==",
+            "dev": true,
+            "requires": {
+                "graphql": "*"
+            }
+        },
         "@types/istanbul-lib-coverage": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
@@ -10614,10 +15307,22 @@
                 "pretty-format": "^27.0.0"
             }
         },
+        "@types/js-yaml": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz",
+            "integrity": "sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==",
+            "dev": true
+        },
         "@types/json-schema": {
             "version": "7.0.9",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
             "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+            "dev": true
+        },
+        "@types/json-stable-stringify": {
+            "version": "1.0.33",
+            "resolved": "https://registry.npmjs.org/@types/json-stable-stringify/-/json-stable-stringify-1.0.33.tgz",
+            "integrity": "sha512-qEWiQff6q2tA5gcJGWwzplQcXdJtm+0oy6IHGHzlOf3eFAkGE/FIPXZK9ofWgNSHVp8AFFI33PJJshS0ei3Gvw==",
             "dev": true
         },
         "@types/json5": {
@@ -10625,6 +15330,15 @@
             "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
             "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
             "dev": true
+        },
+        "@types/jsonwebtoken": {
+            "version": "8.5.8",
+            "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.8.tgz",
+            "integrity": "sha512-zm6xBQpFDIDM6o9r6HSgDeIcLy82TKWctCXEPbJJcXb5AKmi5BNNdLXneixK4lplX3PqIVcwLBCGE/kAGnlD4A==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
         },
         "@types/long": {
             "version": "4.0.1",
@@ -10655,6 +15369,12 @@
                 "@types/node": "*",
                 "form-data": "^3.0.0"
             }
+        },
+        "@types/parse-json": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+            "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+            "dev": true
         },
         "@types/prettier": {
             "version": "2.4.4",
@@ -10707,6 +15427,24 @@
             "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
             "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
             "dev": true
+        },
+        "@types/websocket": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.5.tgz",
+            "integrity": "sha512-NbsqiNX9CnEfC1Z0Vf4mE1SgAJ07JnRYcNex7AJ9zAVzmiGHmjKFEk7O4TJIsgv2B1sLEb6owKFZrACwdYngsQ==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "@types/ws": {
+            "version": "8.5.1",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.1.tgz",
+            "integrity": "sha512-UxlLOfkuQnT2YSBCNq0x86SGOUxas6gAySFeDe2DcnEnA8655UIPoCDorWZCugcvKIL8IUI4oueUfJ1hhZSE2A==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
         },
         "@types/yargs": {
             "version": "16.0.4",
@@ -10943,6 +15681,12 @@
                 "color-convert": "^2.0.1"
             }
         },
+        "any-observable": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
+            "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
+            "dev": true
+        },
         "anymatch": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
@@ -11003,6 +15747,12 @@
             "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
             "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
         },
+        "asap": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+            "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+            "dev": true
+        },
         "asn1": {
             "version": "0.2.4",
             "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -11044,6 +15794,12 @@
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
         },
+        "auto-bind": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz",
+            "integrity": "sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==",
+            "dev": true
+        },
         "aws-sign2": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -11072,6 +15828,15 @@
                 "slash": "^3.0.0"
             }
         },
+        "babel-plugin-dynamic-import-node": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+            "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
+            "dev": true,
+            "requires": {
+                "object.assign": "^4.1.0"
+            }
+        },
         "babel-plugin-istanbul": {
             "version": "6.1.1",
             "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
@@ -11097,6 +15862,12 @@
                 "@types/babel__traverse": "^7.0.6"
             }
         },
+        "babel-plugin-syntax-trailing-function-commas": {
+            "version": "7.0.0-beta.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz",
+            "integrity": "sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==",
+            "dev": true
+        },
         "babel-preset-current-node-syntax": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
@@ -11117,6 +15888,41 @@
                 "@babel/plugin-syntax-top-level-await": "^7.8.3"
             }
         },
+        "babel-preset-fbjs": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-3.4.0.tgz",
+            "integrity": "sha512-9ywCsCvo1ojrw0b+XYk7aFvTH6D9064t0RIL1rtMf3nsa02Xw41MS7sZw216Im35xj/UY0PDBQsa1brUDDF1Ow==",
+            "dev": true,
+            "requires": {
+                "@babel/plugin-proposal-class-properties": "^7.0.0",
+                "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+                "@babel/plugin-syntax-class-properties": "^7.0.0",
+                "@babel/plugin-syntax-flow": "^7.0.0",
+                "@babel/plugin-syntax-jsx": "^7.0.0",
+                "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+                "@babel/plugin-transform-arrow-functions": "^7.0.0",
+                "@babel/plugin-transform-block-scoped-functions": "^7.0.0",
+                "@babel/plugin-transform-block-scoping": "^7.0.0",
+                "@babel/plugin-transform-classes": "^7.0.0",
+                "@babel/plugin-transform-computed-properties": "^7.0.0",
+                "@babel/plugin-transform-destructuring": "^7.0.0",
+                "@babel/plugin-transform-flow-strip-types": "^7.0.0",
+                "@babel/plugin-transform-for-of": "^7.0.0",
+                "@babel/plugin-transform-function-name": "^7.0.0",
+                "@babel/plugin-transform-literals": "^7.0.0",
+                "@babel/plugin-transform-member-expression-literals": "^7.0.0",
+                "@babel/plugin-transform-modules-commonjs": "^7.0.0",
+                "@babel/plugin-transform-object-super": "^7.0.0",
+                "@babel/plugin-transform-parameters": "^7.0.0",
+                "@babel/plugin-transform-property-literals": "^7.0.0",
+                "@babel/plugin-transform-react-display-name": "^7.0.0",
+                "@babel/plugin-transform-react-jsx": "^7.0.0",
+                "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+                "@babel/plugin-transform-spread": "^7.0.0",
+                "@babel/plugin-transform-template-literals": "^7.0.0",
+                "babel-plugin-syntax-trailing-function-commas": "^7.0.0-beta.0"
+            }
+        },
         "babel-preset-jest": {
             "version": "27.5.1",
             "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-27.5.1.tgz",
@@ -11126,6 +15932,12 @@
                 "babel-plugin-jest-hoist": "^27.5.1",
                 "babel-preset-current-node-syntax": "^1.0.0"
             }
+        },
+        "backo2": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+            "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
+            "dev": true
         },
         "balanced-match": {
             "version": "1.0.2",
@@ -11326,6 +16138,16 @@
                 "node-int64": "^0.4.0"
             }
         },
+        "buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "dev": true,
+            "requires": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
+            }
+        },
         "buffer-alloc": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
@@ -11421,6 +16243,24 @@
             "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
             "dev": true
         },
+        "camel-case": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+            "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+            "dev": true,
+            "requires": {
+                "pascal-case": "^3.1.2",
+                "tslib": "^2.0.3"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
         "camelcase": {
             "version": "5.3.1",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -11432,6 +16272,25 @@
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001274.tgz",
             "integrity": "sha512-+Nkvv0fHyhISkiMIjnyjmf5YJcQ1IQHZN6U9TLUMroWR38FNwpsC51Gb68yueafX1V6ifOisInSgP9WJFS13ew==",
             "dev": true
+        },
+        "capital-case": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
+            "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
+            "dev": true,
+            "requires": {
+                "no-case": "^3.0.4",
+                "tslib": "^2.0.3",
+                "upper-case-first": "^2.0.2"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
         },
         "caseless": {
             "version": "0.12.0",
@@ -11458,10 +16317,62 @@
                 "supports-color": "^7.1.0"
             }
         },
+        "change-case": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+            "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+            "dev": true,
+            "requires": {
+                "camel-case": "^4.1.2",
+                "capital-case": "^1.0.4",
+                "constant-case": "^3.0.4",
+                "dot-case": "^3.0.4",
+                "header-case": "^2.0.4",
+                "no-case": "^3.0.4",
+                "param-case": "^3.0.4",
+                "pascal-case": "^3.1.2",
+                "path-case": "^3.0.4",
+                "sentence-case": "^3.0.4",
+                "snake-case": "^3.0.4",
+                "tslib": "^2.0.3"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
+        "change-case-all": {
+            "version": "1.0.14",
+            "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.14.tgz",
+            "integrity": "sha512-CWVm2uT7dmSHdO/z1CXT/n47mWonyypzBbuCy5tN7uMg22BsfkhwT6oHmFCAk+gL1LOOxhdbB9SZz3J1KTY3gA==",
+            "dev": true,
+            "requires": {
+                "change-case": "^4.1.2",
+                "is-lower-case": "^2.0.2",
+                "is-upper-case": "^2.0.2",
+                "lower-case": "^2.0.2",
+                "lower-case-first": "^2.0.2",
+                "sponge-case": "^1.0.1",
+                "swap-case": "^2.0.2",
+                "title-case": "^3.0.3",
+                "upper-case": "^2.0.2",
+                "upper-case-first": "^2.0.2"
+            }
+        },
         "char-regex": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
             "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+            "dev": true
+        },
+        "chardet": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+            "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
             "dev": true
         },
         "chokidar": {
@@ -11525,6 +16436,21 @@
             "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
             "dev": true
         },
+        "cli-cursor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+            "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+            "dev": true,
+            "requires": {
+                "restore-cursor": "^3.1.0"
+            }
+        },
+        "cli-spinners": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
+            "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==",
+            "dev": true
+        },
         "cli-table": {
             "version": "0.3.6",
             "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.6.tgz",
@@ -11533,6 +16459,59 @@
             "requires": {
                 "colors": "1.0.3"
             }
+        },
+        "cli-truncate": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+            "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+            "dev": true,
+            "requires": {
+                "slice-ansi": "0.0.4",
+                "string-width": "^1.0.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "^1.0.0"
+                    }
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "dev": true,
+                    "requires": {
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "cli-width": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+            "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+            "dev": true
         },
         "cliui": {
             "version": "7.0.4",
@@ -11543,6 +16522,12 @@
                 "strip-ansi": "^6.0.0",
                 "wrap-ansi": "^7.0.0"
             }
+        },
+        "clone": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+            "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+            "dev": true
         },
         "clone-response": {
             "version": "1.0.2",
@@ -11557,6 +16542,12 @@
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
             "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+            "dev": true
+        },
+        "code-point-at": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
             "dev": true
         },
         "collect-v8-coverage": {
@@ -11639,6 +16630,12 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
             "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
         },
+        "common-tags": {
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
+            "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
+            "dev": true
+        },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -11674,6 +16671,25 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/console-log-level/-/console-log-level-1.4.1.tgz",
             "integrity": "sha512-VZzbIORbP+PPcN/gg3DXClTLPLg5Slwd5fL2MIc+o1qZ4BXBvWyc6QxPk6T/Mkr6IVjRpoAGf32XxP3ZWMVRcQ=="
+        },
+        "constant-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+            "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+            "dev": true,
+            "requires": {
+                "no-case": "^3.0.4",
+                "tslib": "^2.0.3",
+                "upper-case": "^2.0.2"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
         },
         "content-disposition": {
             "version": "0.5.4",
@@ -11743,6 +16759,28 @@
                 "vary": "^1"
             }
         },
+        "cosmiconfig": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+            "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+            "dev": true,
+            "requires": {
+                "@types/parse-json": "^4.0.0",
+                "import-fresh": "^3.2.1",
+                "parse-json": "^5.0.0",
+                "path-type": "^4.0.0",
+                "yaml": "^1.10.0"
+            }
+        },
+        "cosmiconfig-toml-loader": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig-toml-loader/-/cosmiconfig-toml-loader-1.0.0.tgz",
+            "integrity": "sha512-H/2gurFWVi7xXvCyvsWRLCMekl4tITJcX0QEsDMpzxtuxDyM59xLatYNg4s/k9AA/HdtCYfj2su8mgA0GSDLDA==",
+            "dev": true,
+            "requires": {
+                "@iarna/toml": "^2.2.5"
+            }
+        },
         "create-eslint-index": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/create-eslint-index/-/create-eslint-index-1.0.0.tgz",
@@ -11758,6 +16796,14 @@
             "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
             "dev": true
         },
+        "cross-fetch": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+            "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+            "requires": {
+                "node-fetch": "2.6.7"
+            }
+        },
         "cross-spawn": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -11767,6 +16813,20 @@
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
                 "which": "^2.0.1"
+            }
+        },
+        "cross-undici-fetch": {
+            "version": "0.1.25",
+            "resolved": "https://registry.npmjs.org/cross-undici-fetch/-/cross-undici-fetch-0.1.25.tgz",
+            "integrity": "sha512-KS6hm/VuRO+3jIrg4uidz3mQ8NWvCbiTTOg3yoH30zuGVUvjqZlnXw66h0kuzyfP21hDkrdIbufXCW6BAQdSNw==",
+            "dev": true,
+            "requires": {
+                "abort-controller": "^3.0.0",
+                "form-data-encoder": "^1.7.1",
+                "formdata-node": "^4.3.1",
+                "node-fetch": "^2.6.7",
+                "undici": "^4.9.3",
+                "web-streams-polyfill": "^3.2.0"
             }
         },
         "crypto-random-string": {
@@ -11818,10 +16878,22 @@
                 "whatwg-url": "^8.0.0"
             }
         },
+        "dataloader": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.0.0.tgz",
+            "integrity": "sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ==",
+            "dev": true
+        },
         "date-fns": {
             "version": "2.28.0",
             "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
             "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
+        },
+        "debounce": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+            "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+            "dev": true
         },
         "debug": {
             "version": "4.3.2",
@@ -11830,6 +16902,12 @@
             "requires": {
                 "ms": "2.1.2"
             }
+        },
+        "decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true
         },
         "decimal.js": {
             "version": "10.3.1",
@@ -11870,11 +16948,29 @@
             "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
             "dev": true
         },
+        "defaults": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+            "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+            "dev": true,
+            "requires": {
+                "clone": "^1.0.2"
+            }
+        },
         "defer-to-connect": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
             "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
             "dev": true
+        },
+        "define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "dev": true,
+            "requires": {
+                "object-keys": "^1.0.12"
+            }
         },
         "delayed-stream": {
             "version": "1.0.0",
@@ -11891,10 +16987,22 @@
             "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
             "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
         },
+        "dependency-graph": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
+            "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
+            "dev": true
+        },
         "destroy": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
             "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+        },
+        "detect-indent": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+            "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+            "dev": true
         },
         "detect-newline": {
             "version": "3.1.0",
@@ -11949,6 +17057,24 @@
                 }
             }
         },
+        "dot-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+            "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+            "dev": true,
+            "requires": {
+                "no-case": "^3.0.4",
+                "tslib": "^2.0.3"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
         "dot-prop": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
@@ -11956,6 +17082,18 @@
             "requires": {
                 "is-obj": "^2.0.0"
             }
+        },
+        "dotenv": {
+            "version": "16.0.0",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
+            "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==",
+            "dev": true
+        },
+        "dset": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.1.tgz",
+            "integrity": "sha512-hYf+jZNNqJBD2GiMYb+5mqOIX4R4RRHXU3qWMWYN+rqcR2/YpRL2bUHr8C8fU+5DNvqYjJ8YvMGSLuVPWU1cNg==",
+            "dev": true
         },
         "duplexer3": {
             "version": "0.1.4",
@@ -12001,6 +17139,12 @@
             "version": "1.3.886",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.886.tgz",
             "integrity": "sha512-+vYdeBosI63VkCtNWnEVFjgNd/IZwvnsWkKyPtWAvrhA+XfByKoBJcbsMgudVU/bUcGAF9Xp3aXn96voWlc3oQ==",
+            "dev": true
+        },
+        "elegant-spinner": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+            "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
             "dev": true
         },
         "emitter-listener": {
@@ -12342,6 +17486,12 @@
             "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
             "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
         },
+        "eventemitter3": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+            "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+            "dev": true
+        },
         "eventid": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/eventid/-/eventid-2.0.1.tgz",
@@ -12468,6 +17618,34 @@
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
             "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
         },
+        "external-editor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+            "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+            "dev": true,
+            "requires": {
+                "chardet": "^0.7.0",
+                "iconv-lite": "^0.4.24",
+                "tmp": "^0.0.33"
+            },
+            "dependencies": {
+                "tmp": {
+                    "version": "0.0.33",
+                    "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+                    "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+                    "dev": true,
+                    "requires": {
+                        "os-tmpdir": "~1.0.2"
+                    }
+                }
+            }
+        },
+        "extract-files": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-11.0.0.tgz",
+            "integrity": "sha512-FuoE1qtbJ4bBVvv94CC7s0oTnKUGvQs+Rjf1L2SJFfS+HTVVjhPFtehPdQ0JiGPqVNfSSZvL5yzHHQq2Z4WNhQ==",
+            "dev": true
+        },
         "extsprintf": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -12545,10 +17723,48 @@
                 "bser": "2.1.1"
             }
         },
+        "fbjs": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.4.tgz",
+            "integrity": "sha512-ucV0tDODnGV3JCnnkmoszb5lf4bNpzjv80K41wd4k798Etq+UYD0y0TIfalLjZoKgjive6/adkRnszwapiDgBQ==",
+            "dev": true,
+            "requires": {
+                "cross-fetch": "^3.1.5",
+                "fbjs-css-vars": "^1.0.0",
+                "loose-envify": "^1.0.0",
+                "object-assign": "^4.1.0",
+                "promise": "^7.1.1",
+                "setimmediate": "^1.0.5",
+                "ua-parser-js": "^0.7.30"
+            }
+        },
+        "fbjs-css-vars": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
+            "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==",
+            "dev": true
+        },
         "fecha": {
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
             "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q=="
+        },
+        "figures": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+            "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+            "dev": true,
+            "requires": {
+                "escape-string-regexp": "^1.0.5"
+            },
+            "dependencies": {
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                    "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+                    "dev": true
+                }
+            }
         },
         "file-entry-cache": {
             "version": "6.0.1",
@@ -12642,6 +17858,30 @@
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "mime-types": "^2.1.12"
+            }
+        },
+        "form-data-encoder": {
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.1.tgz",
+            "integrity": "sha512-EFRDrsMm/kyqbTQocNvRXMLjc7Es2Vk+IQFx/YW7hkUH1eBl4J1fqiP34l74Yt0pFLCNpc06fkbVk00008mzjg==",
+            "dev": true
+        },
+        "formdata-node": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.3.2.tgz",
+            "integrity": "sha512-k7lYJyzDOSL6h917favP8j1L0/wNyylzU+x+1w4p5haGVHNlP58dbpdJhiCUsDbWsa9HwEtLp89obQgXl2e0qg==",
+            "dev": true,
+            "requires": {
+                "node-domexception": "1.0.0",
+                "web-streams-polyfill": "4.0.0-beta.1"
+            },
+            "dependencies": {
+                "web-streams-polyfill": {
+                    "version": "4.0.0-beta.1",
+                    "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.1.tgz",
+                    "integrity": "sha512-3ux37gEX670UUphBF9AMCq8XM6iQ8Ac6A+DSRRjDoRBm1ufCkaCDdNVbaqq60PsEkdNlLKrGtv/YBP4EJXqNtQ==",
+                    "dev": true
+                }
             }
         },
         "forwarded": {
@@ -12916,6 +18156,85 @@
             "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
             "dev": true
         },
+        "graphql": {
+            "version": "15.8.0",
+            "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+            "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw=="
+        },
+        "graphql-config": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-4.1.0.tgz",
+            "integrity": "sha512-Myqay6pmdcmX3KqoH+bMbeKZ1cTODpHS2CxF1ZzNnfTE+YUpGTcp01bOw6LpzamRb0T/WTYtGFbZeXGo9Hab2Q==",
+            "dev": true,
+            "requires": {
+                "@endemolshinegroup/cosmiconfig-typescript-loader": "3.0.2",
+                "@graphql-tools/graphql-file-loader": "^7.3.2",
+                "@graphql-tools/json-file-loader": "^7.3.2",
+                "@graphql-tools/load": "^7.4.1",
+                "@graphql-tools/merge": "^8.2.1",
+                "@graphql-tools/url-loader": "^7.4.2",
+                "@graphql-tools/utils": "^8.5.1",
+                "cosmiconfig": "7.0.1",
+                "cosmiconfig-toml-loader": "1.0.0",
+                "minimatch": "3.0.4",
+                "string-env-interpolation": "1.0.1"
+            }
+        },
+        "graphql-executor": {
+            "version": "0.0.18",
+            "resolved": "https://registry.npmjs.org/graphql-executor/-/graphql-executor-0.0.18.tgz",
+            "integrity": "sha512-upUSl7tfZCZ5dWG1XkOvpG70Yk3duZKcCoi/uJso4WxJVT6KIrcK4nZ4+2X/hzx46pL8wAukgYHY6iNmocRN+g==",
+            "dev": true,
+            "requires": {}
+        },
+        "graphql-request": {
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-3.7.0.tgz",
+            "integrity": "sha512-dw5PxHCgBneN2DDNqpWu8QkbbJ07oOziy8z+bK/TAXufsOLaETuVO4GkXrbs0WjhdKhBMN3BkpN/RIvUHkmNUQ==",
+            "requires": {
+                "cross-fetch": "^3.0.6",
+                "extract-files": "^9.0.0",
+                "form-data": "^3.0.0"
+            },
+            "dependencies": {
+                "extract-files": {
+                    "version": "9.0.0",
+                    "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-9.0.0.tgz",
+                    "integrity": "sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ=="
+                }
+            }
+        },
+        "graphql-sse": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/graphql-sse/-/graphql-sse-1.0.6.tgz",
+            "integrity": "sha512-y2mVBN2KwNrzxX2KBncQ6kzc6JWvecxuBernrl0j65hsr6MAS3+Yn8PTFSOgRmtolxugepxveyZVQEuaNEbw3w==",
+            "dev": true,
+            "requires": {}
+        },
+        "graphql-tag": {
+            "version": "2.12.6",
+            "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+            "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+            "dev": true,
+            "requires": {
+                "tslib": "^2.1.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
+        "graphql-ws": {
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.6.2.tgz",
+            "integrity": "sha512-TsjovINNEGfv52uKWYSVCOLX9LFe6wAhf9n7hIsV3zjflky1dv/mAP+kjXAXsnzV1jH5Sx0S73CtBFNvxus+SQ==",
+            "dev": true,
+            "requires": {}
+        },
         "gtoken": {
             "version": "5.3.1",
             "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.3.1.tgz",
@@ -12950,6 +18269,23 @@
                 "function-bind": "^1.1.1"
             }
         },
+        "has-ansi": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "^2.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                }
+            }
+        },
         "has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -12966,6 +18302,24 @@
             "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
             "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
             "dev": true
+        },
+        "header-case": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+            "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+            "dev": true,
+            "requires": {
+                "capital-case": "^1.0.4",
+                "tslib": "^2.0.3"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
         },
         "hex2dec": {
             "version": "1.1.2",
@@ -13050,6 +18404,12 @@
                 "safer-buffer": ">= 2.1.2 < 3"
             }
         },
+        "ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "dev": true
+        },
         "ignore": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -13068,6 +18428,12 @@
             "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
             "dev": true
         },
+        "immutable": {
+            "version": "3.7.6",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
+            "integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks=",
+            "dev": true
+        },
         "import-fresh": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -13077,6 +18443,12 @@
                 "parent-module": "^1.0.0",
                 "resolve-from": "^4.0.0"
             }
+        },
+        "import-from": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
+            "integrity": "sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==",
+            "dev": true
         },
         "import-lazy": {
             "version": "2.1.0",
@@ -13100,6 +18472,12 @@
             "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
             "dev": true
         },
+        "indent-string": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+            "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+            "dev": true
+        },
         "inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -13121,6 +18499,37 @@
             "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
             "dev": true
         },
+        "inquirer": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.0.tgz",
+            "integrity": "sha512-0crLweprevJ02tTuA6ThpoAERAGyVILC4sS74uib58Xf/zSr1/ZWtmm7D5CI+bSQEaA04f0K7idaHpQbSWgiVQ==",
+            "dev": true,
+            "requires": {
+                "ansi-escapes": "^4.2.1",
+                "chalk": "^4.1.1",
+                "cli-cursor": "^3.1.0",
+                "cli-width": "^3.0.0",
+                "external-editor": "^3.0.3",
+                "figures": "^3.0.0",
+                "lodash": "^4.17.21",
+                "mute-stream": "0.0.8",
+                "ora": "^5.4.1",
+                "run-async": "^2.4.0",
+                "rxjs": "^7.2.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0",
+                "through": "^2.3.6"
+            }
+        },
+        "invariant": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+            "dev": true,
+            "requires": {
+                "loose-envify": "^1.0.0"
+            }
+        },
         "ipaddr.js": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -13130,6 +18539,16 @@
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
             "integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg=="
+        },
+        "is-absolute": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+            "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+            "dev": true,
+            "requires": {
+                "is-relative": "^1.0.0",
+                "is-windows": "^1.0.1"
+            }
         },
         "is-arrayish": {
             "version": "0.3.2",
@@ -13206,6 +18625,29 @@
                 "is-path-inside": "^3.0.2"
             }
         },
+        "is-interactive": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+            "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+            "dev": true
+        },
+        "is-lower-case": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-2.0.2.tgz",
+            "integrity": "sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==",
+            "dev": true,
+            "requires": {
+                "tslib": "^2.0.3"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
         "is-npm": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-5.0.0.tgz",
@@ -13223,6 +18665,15 @@
             "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
             "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
         },
+        "is-observable": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
+            "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
+            "dev": true,
+            "requires": {
+                "symbol-observable": "^1.1.0"
+            }
+        },
         "is-path-inside": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -13234,6 +18685,21 @@
             "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
             "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
             "dev": true
+        },
+        "is-promise": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+            "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+            "dev": true
+        },
+        "is-relative": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+            "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+            "dev": true,
+            "requires": {
+                "is-unc-path": "^1.0.0"
+            }
         },
         "is-stream": {
             "version": "2.0.1",
@@ -13249,6 +18715,44 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
             "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+            "dev": true
+        },
+        "is-unc-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+            "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+            "dev": true,
+            "requires": {
+                "unc-path-regex": "^0.1.2"
+            }
+        },
+        "is-unicode-supported": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+            "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+            "dev": true
+        },
+        "is-upper-case": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-2.0.2.tgz",
+            "integrity": "sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==",
+            "dev": true,
+            "requires": {
+                "tslib": "^2.0.3"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
+        "is-windows": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
             "dev": true
         },
         "is-yarn-global": {
@@ -13268,6 +18772,23 @@
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
             "dev": true
+        },
+        "isomorphic-fetch": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+            "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+            "dev": true,
+            "requires": {
+                "node-fetch": "^2.6.1",
+                "whatwg-fetch": "^3.4.1"
+            }
+        },
+        "isomorphic-ws": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+            "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+            "dev": true,
+            "requires": {}
         },
         "isstream": {
             "version": "0.1.2",
@@ -13333,6 +18854,12 @@
                 "html-escaper": "^2.0.0",
                 "istanbul-lib-report": "^3.0.0"
             }
+        },
+        "iterall": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+            "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
+            "dev": true
         },
         "jest": {
             "version": "27.5.1",
@@ -13915,6 +19442,15 @@
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
         },
+        "json-stable-stringify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+            "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+            "dev": true,
+            "requires": {
+                "jsonify": "~0.0.0"
+            }
+        },
         "json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -13926,6 +19462,16 @@
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
             "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
             "dev": true
+        },
+        "json-to-pretty-yaml": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/json-to-pretty-yaml/-/json-to-pretty-yaml-1.2.2.tgz",
+            "integrity": "sha1-9M0L0KXo/h3yWq9boRiwmf2ZLVs=",
+            "dev": true,
+            "requires": {
+                "remedial": "^1.0.7",
+                "remove-trailing-spaces": "^1.0.6"
+            }
         },
         "json5": {
             "version": "2.2.0",
@@ -13944,6 +19490,12 @@
             "requires": {
                 "graceful-fs": "^4.1.6"
             }
+        },
+        "jsonify": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+            "dev": true
         },
         "jsonwebtoken": {
             "version": "8.5.1",
@@ -14134,6 +19686,248 @@
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
             "dev": true
         },
+        "listr": {
+            "version": "0.14.3",
+            "resolved": "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz",
+            "integrity": "sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==",
+            "dev": true,
+            "requires": {
+                "@samverschueren/stream-to-observable": "^0.3.0",
+                "is-observable": "^1.1.0",
+                "is-promise": "^2.1.0",
+                "is-stream": "^1.1.0",
+                "listr-silent-renderer": "^1.1.1",
+                "listr-update-renderer": "^0.5.0",
+                "listr-verbose-renderer": "^0.5.0",
+                "p-map": "^2.0.0",
+                "rxjs": "^6.3.3"
+            },
+            "dependencies": {
+                "is-stream": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                    "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+                    "dev": true
+                },
+                "rxjs": {
+                    "version": "6.6.7",
+                    "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+                    "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^1.9.0"
+                    }
+                }
+            }
+        },
+        "listr-silent-renderer": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+            "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+            "dev": true
+        },
+        "listr-update-renderer": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
+            "integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
+            "dev": true,
+            "requires": {
+                "chalk": "^1.1.3",
+                "cli-truncate": "^0.2.1",
+                "elegant-spinner": "^1.0.1",
+                "figures": "^1.7.0",
+                "indent-string": "^3.0.0",
+                "log-symbols": "^1.0.2",
+                "log-update": "^2.3.0",
+                "strip-ansi": "^3.0.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    }
+                },
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                    "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+                    "dev": true
+                },
+                "figures": {
+                    "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+                    "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+                    "dev": true,
+                    "requires": {
+                        "escape-string-regexp": "^1.0.5",
+                        "object-assign": "^4.1.0"
+                    }
+                },
+                "log-symbols": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+                    "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^1.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
+        "listr-verbose-renderer": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
+            "integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.4.1",
+                "cli-cursor": "^2.1.0",
+                "date-fns": "^1.27.2",
+                "figures": "^2.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "cli-cursor": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+                    "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+                    "dev": true,
+                    "requires": {
+                        "restore-cursor": "^2.0.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "1.9.3",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "1.1.3"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+                    "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+                    "dev": true
+                },
+                "date-fns": {
+                    "version": "1.30.1",
+                    "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+                    "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+                    "dev": true
+                },
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                    "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+                    "dev": true
+                },
+                "figures": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+                    "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+                    "dev": true,
+                    "requires": {
+                        "escape-string-regexp": "^1.0.5"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "mimic-fn": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+                    "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+                    "dev": true
+                },
+                "onetime": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+                    "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+                    "dev": true,
+                    "requires": {
+                        "mimic-fn": "^1.0.0"
+                    }
+                },
+                "restore-cursor": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+                    "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+                    "dev": true,
+                    "requires": {
+                        "onetime": "^2.0.0",
+                        "signal-exit": "^3.0.2"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
         "locate-path": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -14243,6 +20037,110 @@
             "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
             "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg=="
         },
+        "log-symbols": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+            "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+            "dev": true,
+            "requires": {
+                "chalk": "^4.1.0",
+                "is-unicode-supported": "^0.1.0"
+            }
+        },
+        "log-update": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
+            "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
+            "dev": true,
+            "requires": {
+                "ansi-escapes": "^3.0.0",
+                "cli-cursor": "^2.0.0",
+                "wrap-ansi": "^3.0.1"
+            },
+            "dependencies": {
+                "ansi-escapes": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+                    "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+                    "dev": true
+                },
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "cli-cursor": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+                    "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+                    "dev": true,
+                    "requires": {
+                        "restore-cursor": "^2.0.0"
+                    }
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "mimic-fn": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+                    "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+                    "dev": true
+                },
+                "onetime": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+                    "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+                    "dev": true,
+                    "requires": {
+                        "mimic-fn": "^1.0.0"
+                    }
+                },
+                "restore-cursor": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+                    "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+                    "dev": true,
+                    "requires": {
+                        "onetime": "^2.0.0",
+                        "signal-exit": "^3.0.2"
+                    }
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                },
+                "wrap-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
+                    "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^2.1.1",
+                        "strip-ansi": "^4.0.0"
+                    }
+                }
+            }
+        },
         "logform": {
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/logform/-/logform-2.4.0.tgz",
@@ -14259,6 +20157,49 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
             "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+        },
+        "loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "dev": true,
+            "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            }
+        },
+        "lower-case": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+            "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+            "dev": true,
+            "requires": {
+                "tslib": "^2.0.3"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
+        "lower-case-first": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-2.0.2.tgz",
+            "integrity": "sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg==",
+            "dev": true,
+            "requires": {
+                "tslib": "^2.0.3"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
         },
         "lowercase-keys": {
             "version": "1.0.1",
@@ -14336,6 +20277,12 @@
                 "tmpl": "1.0.5"
             }
         },
+        "map-cache": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+            "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+            "dev": true
+        },
         "match-stream": {
             "version": "0.0.2",
             "resolved": "https://registry.npmjs.org/match-stream/-/match-stream-0.0.2.tgz",
@@ -14393,6 +20340,13 @@
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
             "dev": true
+        },
+        "meros": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/meros/-/meros-1.1.4.tgz",
+            "integrity": "sha512-E9ZXfK9iQfG9s73ars9qvvvbSIkJZF5yOo9j4tcwM5tN8mUKfj/EKN5PzOr3ZH0y5wL7dLAHw3RVEfpQV9Q7VQ==",
+            "dev": true,
+            "requires": {}
         },
         "methods": {
             "version": "1.1.2",
@@ -14500,6 +20454,30 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/netrc/-/netrc-0.1.4.tgz",
             "integrity": "sha1-a+lPysqNd63gqWcNxGCRTJRHJEQ=",
+            "dev": true
+        },
+        "no-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+            "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+            "dev": true,
+            "requires": {
+                "lower-case": "^2.0.2",
+                "tslib": "^2.0.3"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
+        "node-domexception": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
             "dev": true
         },
         "node-fetch": {
@@ -14668,6 +20646,18 @@
                 "path-key": "^3.0.0"
             }
         },
+        "nullthrows": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
+            "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
+            "dev": true
+        },
+        "number-is-nan": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+            "dev": true
+        },
         "nwsapi": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
@@ -14694,6 +20684,24 @@
             "version": "1.11.0",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
             "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
+        },
+        "object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true
+        },
+        "object.assign": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+            "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.0",
+                "define-properties": "^1.1.3",
+                "has-symbols": "^1.0.1",
+                "object-keys": "^1.1.1"
+            }
         },
         "on-finished": {
             "version": "2.3.0",
@@ -14740,6 +20748,36 @@
                 "prelude-ls": "^1.2.1",
                 "type-check": "^0.4.0",
                 "word-wrap": "^1.2.3"
+            }
+        },
+        "ora": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+            "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+            "dev": true,
+            "requires": {
+                "bl": "^4.1.0",
+                "chalk": "^4.1.0",
+                "cli-cursor": "^3.1.0",
+                "cli-spinners": "^2.5.0",
+                "is-interactive": "^1.0.0",
+                "is-unicode-supported": "^0.1.0",
+                "log-symbols": "^4.1.0",
+                "strip-ansi": "^6.0.0",
+                "wcwidth": "^1.0.1"
+            },
+            "dependencies": {
+                "bl": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+                    "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+                    "dev": true,
+                    "requires": {
+                        "buffer": "^5.5.0",
+                        "inherits": "^2.0.4",
+                        "readable-stream": "^3.4.0"
+                    }
+                }
             }
         },
         "os-tmpdir": {
@@ -14791,6 +20829,12 @@
                 "p-limit": "^2.2.0"
             }
         },
+        "p-map": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+            "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+            "dev": true
+        },
         "p-timeout": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
@@ -14831,6 +20875,24 @@
             "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
             "dev": true
         },
+        "param-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+            "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+            "dev": true,
+            "requires": {
+                "dot-case": "^3.0.4",
+                "tslib": "^2.0.3"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
         "parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -14838,6 +20900,17 @@
             "dev": true,
             "requires": {
                 "callsites": "^3.0.0"
+            }
+        },
+        "parse-filepath": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
+            "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
+            "dev": true,
+            "requires": {
+                "is-absolute": "^1.0.0",
+                "map-cache": "^0.2.0",
+                "path-root": "^0.1.1"
             }
         },
         "parse-json": {
@@ -14863,6 +20936,42 @@
             "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
             "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
         },
+        "pascal-case": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+            "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+            "dev": true,
+            "requires": {
+                "no-case": "^3.0.4",
+                "tslib": "^2.0.3"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
+        "path-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+            "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+            "dev": true,
+            "requires": {
+                "dot-case": "^3.0.4",
+                "tslib": "^2.0.3"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
         "path-exists": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -14885,6 +20994,21 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+        },
+        "path-root": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+            "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
+            "dev": true,
+            "requires": {
+                "path-root-regex": "^0.1.0"
+            }
+        },
+        "path-root-regex": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+            "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
+            "dev": true
         },
         "path-to-regexp": {
             "version": "0.1.7",
@@ -14981,6 +21105,15 @@
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "dev": true
+        },
+        "promise": {
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+            "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+            "dev": true,
+            "requires": {
+                "asap": "~2.0.3"
+            }
         },
         "promise-throttle": {
             "version": "1.1.2",
@@ -15277,6 +21410,125 @@
                 "rc": "^1.2.8"
             }
         },
+        "relay-compiler": {
+            "version": "12.0.0",
+            "resolved": "https://registry.npmjs.org/relay-compiler/-/relay-compiler-12.0.0.tgz",
+            "integrity": "sha512-SWqeSQZ+AMU/Cr7iZsHi1e78Z7oh00I5SvR092iCJq79aupqJ6Ds+I1Pz/Vzo5uY5PY0jvC4rBJXzlIN5g9boQ==",
+            "dev": true,
+            "requires": {
+                "@babel/core": "^7.14.0",
+                "@babel/generator": "^7.14.0",
+                "@babel/parser": "^7.14.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.14.0",
+                "@babel/types": "^7.0.0",
+                "babel-preset-fbjs": "^3.4.0",
+                "chalk": "^4.0.0",
+                "fb-watchman": "^2.0.0",
+                "fbjs": "^3.0.0",
+                "glob": "^7.1.1",
+                "immutable": "~3.7.6",
+                "invariant": "^2.2.4",
+                "nullthrows": "^1.1.1",
+                "relay-runtime": "12.0.0",
+                "signedsource": "^1.0.0",
+                "yargs": "^15.3.1"
+            },
+            "dependencies": {
+                "cliui": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+                    "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^4.2.0",
+                        "strip-ansi": "^6.0.0",
+                        "wrap-ansi": "^6.2.0"
+                    }
+                },
+                "wrap-ansi": {
+                    "version": "6.2.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+                    "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.0.0",
+                        "string-width": "^4.1.0",
+                        "strip-ansi": "^6.0.0"
+                    }
+                },
+                "y18n": {
+                    "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+                    "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "15.4.1",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+                    "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^6.0.0",
+                        "decamelize": "^1.2.0",
+                        "find-up": "^4.1.0",
+                        "get-caller-file": "^2.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^2.0.0",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^4.2.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^4.0.0",
+                        "yargs-parser": "^18.1.2"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "18.1.3",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+                    "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
+                    }
+                }
+            }
+        },
+        "relay-runtime": {
+            "version": "12.0.0",
+            "resolved": "https://registry.npmjs.org/relay-runtime/-/relay-runtime-12.0.0.tgz",
+            "integrity": "sha512-QU6JKr1tMsry22DXNy9Whsq5rmvwr3LSZiiWV/9+DFpuTWvp+WFhobWMc8TC4OjKFfNhEZy7mOiqUAn5atQtug==",
+            "dev": true,
+            "requires": {
+                "@babel/runtime": "^7.0.0",
+                "fbjs": "^3.0.0",
+                "invariant": "^2.2.4"
+            }
+        },
+        "remedial": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/remedial/-/remedial-1.0.8.tgz",
+            "integrity": "sha512-/62tYiOe6DzS5BqVsNpH/nkGlX45C/Sp6V+NtiN6JQNS1Viay7cWkazmRkrQrdFj2eshDe96SIQNIoMxqhzBOg==",
+            "dev": true
+        },
+        "remove-trailing-separator": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+            "dev": true
+        },
+        "remove-trailing-spaces": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/remove-trailing-spaces/-/remove-trailing-spaces-1.0.8.tgz",
+            "integrity": "sha512-O3vsMYfWighyFbTd8hk8VaSj9UAGENxAtX+//ugIst2RMk5e03h6RoIS+0ylsFxY1gvmPuAY/PO4It+gPEeySA==",
+            "dev": true
+        },
+        "replaceall": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/replaceall/-/replaceall-0.1.6.tgz",
+            "integrity": "sha1-gdgax663LX9cSUKt8ml6MiBojY4=",
+            "dev": true
+        },
         "req-all": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/req-all/-/req-all-0.1.0.tgz",
@@ -15361,6 +21613,12 @@
                 "resolve": "^1.12.0"
             }
         },
+        "require-main-filename": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+            "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+            "dev": true
+        },
         "resolve": {
             "version": "1.20.0",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
@@ -15408,6 +21666,16 @@
                 "lowercase-keys": "^1.0.0"
             }
         },
+        "restore-cursor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+            "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+            "dev": true,
+            "requires": {
+                "onetime": "^5.1.0",
+                "signal-exit": "^3.0.2"
+            }
+        },
         "retry-request": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.2.2.tgz",
@@ -15432,6 +21700,12 @@
                 "glob": "^7.1.3"
             }
         },
+        "run-async": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+            "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+            "dev": true
+        },
         "run-parallel": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -15439,6 +21713,23 @@
             "dev": true,
             "requires": {
                 "queue-microtask": "^1.2.2"
+            }
+        },
+        "rxjs": {
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.4.tgz",
+            "integrity": "sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==",
+            "dev": true,
+            "requires": {
+                "tslib": "^2.1.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
             }
         },
         "safe-buffer": {
@@ -15464,6 +21755,12 @@
             "requires": {
                 "xmlchars": "^2.2.0"
             }
+        },
+        "scuid": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/scuid/-/scuid-1.1.0.tgz",
+            "integrity": "sha512-MuCAyrGZcTLfQoH2XoBlQ8C6bzwN88XT/0slOGz0pn8+gIP85BOAfYa44ZXQUTOwRwPU0QvgU+V+OSajl/59Xg==",
+            "dev": true
         },
         "semver": {
             "version": "7.3.5",
@@ -15532,6 +21829,25 @@
                 }
             }
         },
+        "sentence-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+            "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+            "dev": true,
+            "requires": {
+                "no-case": "^3.0.4",
+                "tslib": "^2.0.3",
+                "upper-case-first": "^2.0.2"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
         "serve-static": {
             "version": "1.14.2",
             "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.2.tgz",
@@ -15542,6 +21858,12 @@
                 "parseurl": "~1.3.3",
                 "send": "0.17.2"
             }
+        },
+        "set-blocking": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+            "dev": true
         },
         "set-immediate-shim": {
             "version": "1.0.1",
@@ -15596,6 +21918,12 @@
             "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
             "dev": true
         },
+        "signedsource": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/signedsource/-/signedsource-1.0.0.tgz",
+            "integrity": "sha1-HdrOSYF5j5O9gzlzgD2A1S6TrWo=",
+            "dev": true
+        },
         "simple-swizzle": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -15614,6 +21942,12 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
             "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+            "dev": true
+        },
+        "slice-ansi": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+            "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
             "dev": true
         },
         "slice-stream": {
@@ -15651,6 +21985,24 @@
                 }
             }
         },
+        "snake-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+            "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+            "dev": true,
+            "requires": {
+                "dot-case": "^3.0.4",
+                "tslib": "^2.0.3"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
         "source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -15663,6 +22015,23 @@
             "requires": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
+            }
+        },
+        "sponge-case": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-1.0.1.tgz",
+            "integrity": "sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==",
+            "dev": true,
+            "requires": {
+                "tslib": "^2.0.3"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
             }
         },
         "sprintf-js": {
@@ -15743,6 +22112,12 @@
                 }
             }
         },
+        "string-env-interpolation": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/string-env-interpolation/-/string-env-interpolation-1.0.1.tgz",
+            "integrity": "sha512-78lwMoCcn0nNu8LszbP1UA7g55OeE4v7rCeWnM5B453rnNr4aq+5it3FEYtZrSEiMvHZOZ9Jlqb0OD0M2VInqg==",
+            "dev": true
+        },
         "string-length": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -15794,6 +22169,19 @@
             "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
             "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls="
         },
+        "subscriptions-transport-ws": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.11.0.tgz",
+            "integrity": "sha512-8D4C6DIH5tGiAIpp5I0wD/xRlNiZAPGHygzCe7VzyzUoxHtawzjNAY9SUTXU05/EY2NMY9/9GF0ycizkXr1CWQ==",
+            "dev": true,
+            "requires": {
+                "backo2": "^1.0.2",
+                "eventemitter3": "^3.1.0",
+                "iterall": "^1.2.1",
+                "symbol-observable": "^1.0.4",
+                "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
+            }
+        },
         "supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -15813,11 +22201,44 @@
                 "supports-color": "^7.0.0"
             }
         },
+        "swap-case": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-2.0.2.tgz",
+            "integrity": "sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==",
+            "dev": true,
+            "requires": {
+                "tslib": "^2.0.3"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
+        "symbol-observable": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+            "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+            "dev": true
+        },
         "symbol-tree": {
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true
+        },
+        "sync-fetch": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/sync-fetch/-/sync-fetch-0.3.1.tgz",
+            "integrity": "sha512-xj5qiCDap/03kpci5a+qc5wSJjc8ZSixgG2EUmH1B8Ea2sfWclQA7eH40hiHPCtkCn6MCk4Wb+dqcXdCy2PP3g==",
+            "dev": true,
+            "requires": {
+                "buffer": "^5.7.0",
+                "node-fetch": "^2.6.1"
+            }
         },
         "tar-fs": {
             "version": "1.16.3",
@@ -15951,12 +22372,35 @@
             "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
             "dev": true
         },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
+        },
         "timezone-support": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/timezone-support/-/timezone-support-2.0.2.tgz",
             "integrity": "sha512-J/1PyHCX76vOPuJzCyHMQMH2wTjXCJ30R5EXaS/QTi+xYsL0thS0pubDrHCWnfG4zU1jpPJtctnBBRCOpcJZeQ==",
             "requires": {
                 "commander": "2.20.0"
+            }
+        },
+        "title-case": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/title-case/-/title-case-3.0.3.tgz",
+            "integrity": "sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==",
+            "dev": true,
+            "requires": {
+                "tslib": "^2.0.3"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
             }
         },
         "tmp": {
@@ -16061,6 +22505,12 @@
                 "semver": "7.x",
                 "yargs-parser": "20.x"
             }
+        },
+        "ts-log": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/ts-log/-/ts-log-2.2.4.tgz",
+            "integrity": "sha512-DEQrfv6l7IvN2jlzc/VTdZJYsWUnQNCsueYjMkC/iXoEoi5fNan6MjeDqkvhfzbmHgdz9UxDUluX3V5HdjTydQ==",
+            "dev": true
         },
         "ts-node": {
             "version": "10.5.0",
@@ -16205,6 +22655,18 @@
             "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
             "dev": true
         },
+        "ua-parser-js": {
+            "version": "0.7.31",
+            "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
+            "integrity": "sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==",
+            "dev": true
+        },
+        "unc-path-regex": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+            "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+            "dev": true
+        },
         "undefsafe": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
@@ -16215,6 +22677,12 @@
             "version": "1.13.1",
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
             "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
+            "dev": true
+        },
+        "undici": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-4.14.1.tgz",
+            "integrity": "sha512-WJ+g+XqiZcATcBaUeluCajqy4pEDcQfK1vy+Fo+bC4/mqXI9IIQD/XWHLS70fkGUT6P52Drm7IFslO651OdLPQ==",
             "dev": true
         },
         "unique-string": {
@@ -16231,6 +22699,26 @@
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
             "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
             "dev": true
+        },
+        "unixify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz",
+            "integrity": "sha1-OmQcjC/7zk2mg6XHDwOkYpQMIJA=",
+            "dev": true,
+            "requires": {
+                "normalize-path": "^2.1.1"
+            },
+            "dependencies": {
+                "normalize-path": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                    "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+                    "dev": true,
+                    "requires": {
+                        "remove-trailing-separator": "^1.0.1"
+                    }
+                }
+            }
         },
         "unpipe": {
             "version": "1.0.0",
@@ -16257,6 +22745,40 @@
                 "semver": "^7.3.4",
                 "semver-diff": "^3.1.1",
                 "xdg-basedir": "^4.0.0"
+            }
+        },
+        "upper-case": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+            "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+            "dev": true,
+            "requires": {
+                "tslib": "^2.0.3"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
+        },
+        "upper-case-first": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+            "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+            "dev": true,
+            "requires": {
+                "tslib": "^2.0.3"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
             }
         },
         "uri-js": {
@@ -16323,6 +22845,18 @@
                 }
             }
         },
+        "valid-url": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+            "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA=",
+            "dev": true
+        },
+        "value-or-promise": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.11.tgz",
+            "integrity": "sha512-41BrgH+dIbCFXClcSapVs5M6GkENd3gQOJpEfPDNa71LsUGMXDL0jMWpI/Rh7WhX+Aalfz2TTS3Zt5pUsbnhLg==",
+            "dev": true
+        },
         "vary": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -16366,6 +22900,21 @@
                 "makeerror": "1.0.12"
             }
         },
+        "wcwidth": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+            "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+            "dev": true,
+            "requires": {
+                "defaults": "^1.0.3"
+            }
+        },
+        "web-streams-polyfill": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
+            "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==",
+            "dev": true
+        },
         "webidl-conversions": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
@@ -16380,6 +22929,12 @@
             "requires": {
                 "iconv-lite": "0.4.24"
             }
+        },
+        "whatwg-fetch": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+            "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
+            "dev": true
         },
         "whatwg-mimetype": {
             "version": "2.3.0",
@@ -16406,6 +22961,12 @@
             "requires": {
                 "isexe": "^2.0.0"
             }
+        },
+        "which-module": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+            "dev": true
         },
         "widest-line": {
             "version": "3.1.0",
@@ -16524,6 +23085,18 @@
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
+        "yaml": {
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+            "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+            "dev": true
+        },
+        "yaml-ast-parser": {
+            "version": "0.0.43",
+            "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
+            "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
+            "dev": true
+        },
         "yargs": {
             "version": "16.2.0",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -16547,6 +23120,12 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
             "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+            "dev": true
+        },
+        "yocto-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
             "dev": true
         }
     }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
         "apigee": "./scripts/deploy-apigee.sh",
         "transpile": "tsc",
         "populate-env-vars": "ts-node ./scripts/environment.ts",
-        "unused-exports": "node --require ts-node/register/transpile-only scripts/unused-exports.ts"
+        "unused-exports": "node --require ts-node/register/transpile-only scripts/unused-exports.ts",
+        "codegen": "graphql-codegen --config codegen.yml"
     },
     "dependencies": {
         "@entur/sdk": "^4.4.0",
@@ -38,6 +39,7 @@
         "date-fns": "^2.28.0",
         "express": "^4.17.3",
         "express-jwt": "^6.1.0",
+        "graphql-request": "^3.7.0",
         "jwks-rsa": "^2.0.5",
         "lz-string": "^1.4.4",
         "node-fetch": "^2.6.7",
@@ -49,9 +51,14 @@
     },
     "devDependencies": {
         "@babel/code-frame": "^7.16.7",
+        "@graphql-codegen/cli": "2.4.0",
+        "@graphql-codegen/typescript": "2.4.2",
+        "@graphql-codegen/typescript-graphql-files-modules": "2.1.1",
+        "@graphql-codegen/typescript-operations": "2.2.2",
         "@types/babel__code-frame": "^7.0.3",
         "@types/cors": "^2.8.12",
         "@types/express": "^4.17.13",
+        "@types/graphql": "^14.5.0",
         "@types/jest": "^27.4.0",
         "@types/lz-string": "^1.3.34",
         "@types/node": "16.11.6",
@@ -65,6 +72,7 @@
         "eslint": "^8.9.0",
         "eslint-plugin-fp": "^2.3.0",
         "eslint-plugin-prettier": "^4.0.0",
+        "graphql": "^15.8.0",
         "jest": "^27.5.1",
         "nodemon": "^2.0.15",
         "prettier": "2.5.1",

--- a/scripts/unused-exports.ts
+++ b/scripts/unused-exports.ts
@@ -87,8 +87,7 @@ async function main(): Promise<void> {
     const timeStart = Date.now()
 
     const result = analyzeTsConfig(tsConfigFilePath, [
-        '--excludePathsFromReport=src/index.ts',
-        '--ignoreFiles=types/Api',
+        '--excludePathsFromReport=src/generated/graphql.ts',
     ])
 
     const timeEnd = Date.now()

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -1,0 +1,4117 @@
+export type Maybe<T> = T | null
+export type InputMaybe<T> = Maybe<T>
+export type Exact<T extends { [key: string]: unknown }> = {
+    [K in keyof T]: T[K]
+}
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
+    [SubKey in K]?: Maybe<T[SubKey]>
+}
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
+    [SubKey in K]: Maybe<T[SubKey]>
+}
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+    ID: string
+    String: string
+    Boolean: boolean
+    Int: number
+    Float: number
+    /** List of coordinates like: [[60.89, 11.12], [62.56, 12.10]] */
+    Coordinates: Array<[lat: number, lon: number]>
+    /** Local date using the ISO 8601 format: `YYYY-MM-DD`. Example: `2020-05-17`. */
+    Date: string
+    /**
+     * DateTime format accepting ISO 8601 dates with time zone offset.
+     *
+     * Format:  `YYYY-MM-DD'T'hh:mm[:ss](Z|±01:00)`
+     *
+     * Example: `2017-04-23T18:25:43+02:00` or `2017-04-23T16:25:43Z`
+     */
+    DateTime: string
+    /** A linear function to calculate a value(y) based on a parameter (x): `y = f(x) = a + bx`. It allows setting both a constant(a) and a coefficient(b) and the use those in the computation. Format: `a + b x`. Example: `1800 + 2.0 x` */
+    DoubleFunction: string
+    /** Time using the format: HH:mm:SS. Example: 18:25:SS */
+    LocalTime: string
+    /** Long type */
+    Long: number
+    /** Time using the format: `HH:MM:SS`. Example: `18:25:43` */
+    Time: string
+}
+
+export enum AbsoluteDirection {
+    East = 'east',
+    North = 'north',
+    Northeast = 'northeast',
+    Northwest = 'northwest',
+    South = 'south',
+    Southeast = 'southeast',
+    Southwest = 'southwest',
+    West = 'west',
+}
+
+export enum ArrivalDeparture {
+    /** Only show arrivals */
+    Arrivals = 'arrivals',
+    /** Show both arrivals and departures */
+    Both = 'both',
+    /** Only show departures */
+    Departures = 'departures',
+}
+
+/** Authority involved in public transportation. An organisation under which the responsibility of organising the transport service in a certain area is placed. */
+export type Authority = {
+    __typename?: 'Authority'
+    fareUrl: Maybe<Scalars['String']>
+    id: Scalars['ID']
+    lang: Maybe<Scalars['String']>
+    lines: Array<Maybe<Line>>
+    name: Scalars['String']
+    phone: Maybe<Scalars['String']>
+    /** Get all situations active for the authority. */
+    situations: Array<Maybe<PtSituationElement>>
+    timezone: Scalars['String']
+    url: Maybe<Scalars['String']>
+}
+
+export enum BicycleOptimisationMethod {
+    Flat = 'flat',
+    Greenways = 'greenways',
+    Quick = 'quick',
+    Safe = 'safe',
+    Transfers = 'transfers',
+    Triangle = 'triangle',
+}
+
+export type BikePark = PlaceInterface & {
+    __typename?: 'BikePark'
+    id: Scalars['ID']
+    latitude: Maybe<Scalars['Float']>
+    longitude: Maybe<Scalars['Float']>
+    name: Scalars['String']
+    realtime: Maybe<Scalars['Boolean']>
+    spacesAvailable: Maybe<Scalars['Int']>
+}
+
+export type BikeRentalStation = PlaceInterface & {
+    __typename?: 'BikeRentalStation'
+    allowDropoff: Maybe<Scalars['Boolean']>
+    bikesAvailable: Maybe<Scalars['Int']>
+    id: Scalars['ID']
+    latitude: Maybe<Scalars['Float']>
+    longitude: Maybe<Scalars['Float']>
+    name: Scalars['String']
+    networks: Array<Maybe<Scalars['String']>>
+    realtimeOccupancyAvailable: Maybe<Scalars['Boolean']>
+    spacesAvailable: Maybe<Scalars['Int']>
+}
+
+export enum BikesAllowed {
+    /** The vehicle being used on this particular trip can accommodate at least one bicycle. */
+    Allowed = 'allowed',
+    /** There is no bike information for the trip. */
+    NoInformation = 'noInformation',
+    /** No bicycles are allowed on this trip. */
+    NotAllowed = 'notAllowed',
+}
+
+export type BookingArrangement = {
+    __typename?: 'BookingArrangement'
+    /** Time constraints for booking */
+    bookWhen: Maybe<PurchaseWhen>
+    /** Who should ticket be contacted for booking */
+    bookingContact: Maybe<Contact>
+    /** How should service be booked? */
+    bookingMethods: Maybe<Array<Maybe<BookingMethod>>>
+    /** Textual description of booking arrangement for service */
+    bookingNote: Maybe<Scalars['String']>
+    /** How many days prior to the travel the service needs to be booked */
+    latestBookingDay: Maybe<Scalars['Int']>
+    /** Latest time the service can be booked. ISO 8601 timestamp */
+    latestBookingTime: Maybe<Scalars['LocalTime']>
+    /** Minimum period in advance service can be booked as a ISO 8601 duration */
+    minimumBookingPeriod: Maybe<Scalars['String']>
+}
+
+export enum BookingMethod {
+    CallDriver = 'callDriver',
+    CallOffice = 'callOffice',
+    Online = 'online',
+    PhoneAtStop = 'phoneAtStop',
+    Text = 'text',
+}
+
+export type Branding = {
+    __typename?: 'Branding'
+    /** Description of branding. */
+    description: Maybe<Scalars['String']>
+    id: Maybe<Scalars['ID']>
+    /** URL to an image be used for branding */
+    image: Maybe<Scalars['String']>
+    /** Full name to be used for branding. */
+    name: Maybe<Scalars['String']>
+    /** Short name to be used for branding. */
+    shortName: Maybe<Scalars['String']>
+    /** URL to be used for branding */
+    url: Maybe<Scalars['String']>
+}
+
+export type Contact = {
+    __typename?: 'Contact'
+    /** Name of person to contact */
+    contactPerson: Maybe<Scalars['String']>
+    /** Email adress for contact */
+    email: Maybe<Scalars['String']>
+    /** Textual description of how to get in contact */
+    furtherDetails: Maybe<Scalars['String']>
+    /** Phone number for contact */
+    phone: Maybe<Scalars['String']>
+    /** Url for contact */
+    url: Maybe<Scalars['String']>
+}
+
+/** An advertised destination of a specific journey pattern, usually displayed on a head sign or at other on-board locations. */
+export type DestinationDisplay = {
+    __typename?: 'DestinationDisplay'
+    /** Name of destination to show on front of vehicle. */
+    frontText: Maybe<Scalars['String']>
+    /** Intermediary destinations which the vehicle will pass before reaching its final destination. */
+    via: Maybe<Array<Maybe<Scalars['String']>>>
+}
+
+export enum DirectionType {
+    Anticlockwise = 'anticlockwise',
+    Clockwise = 'clockwise',
+    Inbound = 'inbound',
+    Outbound = 'outbound',
+    Unknown = 'unknown',
+}
+
+/** List of visits to quays as part of vehicle journeys. Updated with real time information where available */
+export type EstimatedCall = {
+    __typename?: 'EstimatedCall'
+    /** Actual time of arrival at quay. Updated from real time information if available. NOT IMPLEMENTED */
+    actualArrivalTime: Maybe<Scalars['DateTime']>
+    /** Actual time of departure from quay. Updated with real time information if available. NOT IMPLEMENTED */
+    actualDepartureTime: Maybe<Scalars['DateTime']>
+    /** Scheduled time of arrival at quay. Not affected by read time updated */
+    aimedArrivalTime: Scalars['DateTime']
+    /** Scheduled time of departure from quay. Not affected by read time updated */
+    aimedDepartureTime: Scalars['DateTime']
+    /** Booking arrangements for this EstimatedCall. */
+    bookingArrangements: Maybe<BookingArrangement>
+    /** Whether stop is cancelled. This means that either the ServiceJourney has a planned cancellation, the ServiceJourney has been cancelled by realtime data, or this particular StopPoint has been cancelled. This also means that both boarding and alighting has been cancelled. */
+    cancellation: Scalars['Boolean']
+    /** The date the estimated call is valid for. */
+    date: Maybe<Scalars['Date']>
+    destinationDisplay: Maybe<DestinationDisplay>
+    /** Expected time of arrival at quay. Updated with real time information if available. Will be null if an actualArrivalTime exists */
+    expectedArrivalTime: Scalars['DateTime']
+    /** Expected time of departure from quay. Updated with real time information if available. Will be null if an actualDepartureTime exists */
+    expectedDepartureTime: Scalars['DateTime']
+    /** Whether vehicle may be alighted at quay according to the planned data. If the cancellation flag is set, alighting is not possible, even if this field is set to true. */
+    forAlighting: Scalars['Boolean']
+    /** Whether vehicle may be boarded at quay according to the planned data. If the cancellation flag is set, boarding is not possible, even if this field is set to true. */
+    forBoarding: Scalars['Boolean']
+    notices: Array<Notice>
+    /** Whether the updated estimates are expected to be inaccurate. NOT IMPLEMENTED */
+    predictionInaccurate: Scalars['Boolean']
+    quay: Maybe<Quay>
+    /** Whether this call has been updated with real time information. */
+    realtime: Scalars['Boolean']
+    realtimeState: RealtimeState
+    /** Whether vehicle will only stop on request. */
+    requestStop: Scalars['Boolean']
+    serviceJourney: Maybe<ServiceJourney>
+    /** Get all relevant situations for this EstimatedCall. */
+    situations: Array<PtSituationElement>
+    stopPositionInPattern: Maybe<Scalars['Int']>
+    /** Whether this is a timing point or not. Boarding and alighting is not allowed at timing points. */
+    timingPoint: Scalars['Boolean']
+}
+
+export enum FilterPlaceType {
+    /** Bicycle rent stations */
+    BicycleRent = 'bicycleRent',
+    /** Bike parks */
+    BikePark = 'bikePark',
+    /** Car parks */
+    CarPark = 'carPark',
+    /** Quay */
+    Quay = 'quay',
+    /** StopPlace */
+    StopPlace = 'stopPlace',
+}
+
+/** Filter trips by disallowing lines involving certain elements. If both lines and authorities are specified, only one must be valid for each line to be banned. If a line is both banned and whitelisted, it will be counted as banned. */
+export type InputBanned = {
+    /** Set of ids for authorities that should not be used */
+    authorities: InputMaybe<Array<InputMaybe<Scalars['ID']>>>
+    /** Set of ids for lines that should not be used */
+    lines: InputMaybe<Array<InputMaybe<Scalars['ID']>>>
+    /** Set of ids of quays that should not be allowed for boarding or alighting. Trip patterns that travel through the quay will still be permitted. */
+    quays: InputMaybe<Array<InputMaybe<Scalars['ID']>>>
+    /** Set of ids of quays that should not be allowed for boarding, alighting or traveling thorugh. */
+    quaysHard: InputMaybe<Array<InputMaybe<Scalars['ID']>>>
+    /** Set of ids of service journeys that should not be used. */
+    serviceJourneys: InputMaybe<Array<InputMaybe<Scalars['ID']>>>
+}
+
+/** Input type for coordinates in the WGS84 system */
+export type InputCoordinates = {
+    /** The latitude of the place. */
+    latitude: Scalars['Float']
+    /** The longitude of the place. */
+    longitude: Scalars['Float']
+}
+
+export enum InputField {
+    DateTime = 'dateTime',
+    From = 'from',
+    To = 'to',
+}
+
+export type InputPlaceIds = {
+    /** Bike parks to include by id. */
+    bikeParks: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+    /** Bike rentals to include by id. */
+    bikeRentalStations: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+    /** Car parks to include by id. */
+    carParks: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+    /** Lines to include by id. */
+    lines: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+    /** Quays to include by id. */
+    quays: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+}
+
+/** Filter trips by only allowing lines involving certain elements. If both lines and authorities are specified, only one must be valid for each line to be used. If a line is both banned and whitelisted, it will be counted as banned. */
+export type InputWhiteListed = {
+    /** Set of ids for authorities that should be used */
+    authorities: InputMaybe<Array<InputMaybe<Scalars['ID']>>>
+    /** Set of ids for lines that should be used */
+    lines: InputMaybe<Array<InputMaybe<Scalars['ID']>>>
+}
+
+export type Interchange = {
+    __typename?: 'Interchange'
+    /** @deprecated This is the same as using the `fromServiceJourney { line }` field. */
+    FromLine: Maybe<Line>
+    /** @deprecated Use fromServiceJourney instead */
+    FromServiceJourney: Maybe<ServiceJourney>
+    /** @deprecated This is the same as using the `toServiceJourney { line }` field. */
+    ToLine: Maybe<Line>
+    /** @deprecated Use toServiceJourney instead */
+    ToServiceJourney: Maybe<ServiceJourney>
+    fromServiceJourney: Maybe<ServiceJourney>
+    guaranteed: Maybe<Scalars['Boolean']>
+    /** Maximum time after scheduled departure time the connecting transport is guarantied to wait for the delayed trip. [NOT RESPECTED DURING ROUTING, JUST PASSED THROUGH] */
+    maximumWaitTime: Maybe<Scalars['Int']>
+    /** The transfer priority is used to decide where a transfer should happen, at the highest prioritized location. If the guarantied flag is set it take precedence priority. A guarantied ALLOWED transfer is preferred over a PREFERRED none-guarantied transfer. */
+    priority: Maybe<InterchangePriority>
+    staySeated: Maybe<Scalars['Boolean']>
+    toServiceJourney: Maybe<ServiceJourney>
+}
+
+export enum InterchangePriority {
+    Allowed = 'allowed',
+    NotAllowed = 'notAllowed',
+    Preferred = 'preferred',
+    Recommended = 'recommended',
+}
+
+export enum InterchangeWeighting {
+    /** Third highest priority interchange. */
+    InterchangeAllowed = 'interchangeAllowed',
+    /** Interchange not allowed. */
+    NoInterchange = 'noInterchange',
+    /** Highest priority interchange. */
+    PreferredInterchange = 'preferredInterchange',
+    /** Second highest priority interchange. */
+    RecommendedInterchange = 'recommendedInterchange',
+}
+
+/** Parameters for the OTP Itinerary Filter Chain. These parameters SHOULD be configured on the server side and should not be used by the client. They are made available here to be able to experiment and tune the server. */
+export type ItineraryFilters = {
+    /** Pick ONE itinerary from each group after putting itineraries that is 85% similar together. */
+    groupSimilarityKeepOne: InputMaybe<Scalars['Float']>
+    /** Reduce the number of itineraries in each group to to maximum 3 itineraries. The itineraries are grouped by similar legs (on board same journey). So, if  68% of the distance is traveled by similar legs, then two itineraries are in the same group. Default value is 68%, must be at least 50%. */
+    groupSimilarityKeepThree: InputMaybe<Scalars['Float']>
+    /** Of the itineraries grouped to maximum of three itineraries, how much worse can the non-grouped legs be compared to the lowest cost. 2.0 means that they can be double the cost, and any itineraries having a higher cost will be filtered. Default value is 2.0, use a value lower than 1.0 to turn off */
+    groupedOtherThanSameLegsMaxCostMultiplier: InputMaybe<Scalars['Float']>
+    /** Set a relative limit for all transit itineraries. The limit is calculated based on the best transit itinerary generalized-cost. Itineraries without transit legs are excluded from this filter. Example: f(x) = 3600 + 2.0 x. If the lowest cost returned is 10 000, then the limit is set to: 3 600 + 2 * 10 000 = 26 600. Then all itineraries with at least one transit leg and a cost above 26 600 is removed from the result. Default: 3600.0 + 2.5 x */
+    transitGeneralizedCostLimit: InputMaybe<Scalars['DoubleFunction']>
+}
+
+export type JourneyPattern = {
+    __typename?: 'JourneyPattern'
+    directionType: Maybe<DirectionType>
+    id: Scalars['ID']
+    line: Line
+    name: Maybe<Scalars['String']>
+    notices: Array<Maybe<Notice>>
+    pointsOnLink: Maybe<PointsOnLink>
+    /** Quays visited by service journeys for this journey patterns */
+    quays: Array<Quay>
+    serviceJourneys: Array<ServiceJourney>
+    /** List of service journeys for the journey pattern for a given date */
+    serviceJourneysForDate: Array<ServiceJourney>
+    /** Get all situations active for the journey pattern. */
+    situations: Array<Maybe<PtSituationElement>>
+}
+
+export type JourneyPatternServiceJourneysForDateArgs = {
+    date?: InputMaybe<Scalars['Date']>
+}
+
+/** Part of a trip pattern. Either a ride on a public transport vehicle or access or path link to/from/between places */
+export type Leg = {
+    __typename?: 'Leg'
+    /** The aimed date and time this leg ends. */
+    aimedEndTime: Scalars['DateTime']
+    /** The aimed date and time this leg starts. */
+    aimedStartTime: Scalars['DateTime']
+    /** For ride legs, the service authority used for this legs. For non-ride legs, null. */
+    authority: Maybe<Authority>
+    bikeRentalNetworks: Array<Maybe<Scalars['String']>>
+    bookingArrangements: Maybe<BookingArrangement>
+    /** NOT IMPLEMENTED */
+    directDuration: Maybe<Scalars['Long']>
+    /** The distance traveled while traversing the leg in meters. */
+    distance: Maybe<Scalars['Float']>
+    /** The legs's duration in seconds */
+    duration: Maybe<Scalars['Long']>
+    /** The expected, realtime adjusted date and time this leg ends. */
+    expectedEndTime: Scalars['DateTime']
+    /** The expected, realtime adjusted date and time this leg starts. */
+    expectedStartTime: Scalars['DateTime']
+    /** EstimatedCall for the quay where the leg originates. */
+    fromEstimatedCall: Maybe<EstimatedCall>
+    /** The Place where the leg originates. */
+    fromPlace: Place
+    /** Generalized cost or weight of the leg. Used for debugging. */
+    generalizedCost: Maybe<Scalars['Int']>
+    interchangeFrom: Maybe<Interchange>
+    interchangeTo: Maybe<Interchange>
+    /** For ride legs, estimated calls for quays between the Place where the leg originates and the Place where the leg ends. For non-ride legs, empty list. */
+    intermediateEstimatedCalls: Array<EstimatedCall>
+    /** For ride legs, intermediate quays between the Place where the leg originates and the Place where the leg ends. For non-ride legs, empty list. */
+    intermediateQuays: Array<Quay>
+    /** For ride legs, the line. For non-ride legs, null. */
+    line: Maybe<Line>
+    /** The mode of transport or access (e.g., foot) used when traversing this leg. */
+    mode: Mode
+    /** For ride legs, the operator used for this legs. For non-ride legs, null. */
+    operator: Maybe<Operator>
+    /** The leg's geometry. */
+    pointsOnLink: Maybe<PointsOnLink>
+    /** Whether there is real-time data about this leg */
+    realtime: Scalars['Boolean']
+    /** Whether this leg is with a rented bike. */
+    rentedBike: Maybe<Scalars['Boolean']>
+    /** Whether this leg is a ride leg or not. */
+    ride: Scalars['Boolean']
+    /** For ride legs, the service journey. For non-ride legs, null. */
+    serviceJourney: Maybe<ServiceJourney>
+    /** For ride legs, all estimated calls for the service journey. For non-ride legs, empty list. */
+    serviceJourneyEstimatedCalls: Array<EstimatedCall>
+    /** All relevant situations for this leg */
+    situations: Array<PtSituationElement>
+    /** Do we continue from a specified via place */
+    steps: Array<Maybe<PathGuidance>>
+    /** EstimatedCall for the quay where the leg ends. */
+    toEstimatedCall: Maybe<EstimatedCall>
+    /** The Place where the leg ends. */
+    toPlace: Place
+    /** The transport sub mode (e.g., localBus or expressBus) used when traversing this leg. Null if leg is not a ride */
+    transportSubmode: Maybe<TransportSubmode>
+    /** Whether this leg is walking with a bike. */
+    walkingBike: Maybe<Scalars['Boolean']>
+}
+
+/** A group of routes which is generally known to the public by a similar name or number */
+export type Line = {
+    __typename?: 'Line'
+    authority: Maybe<Authority>
+    bikesAllowed: Maybe<BikesAllowed>
+    /**
+     * Booking arrangements for flexible line.
+     * @deprecated BookingArrangements are defined per stop, and can be found under `passingTimes` or `estimatedCalls`
+     */
+    bookingArrangements: Maybe<BookingArrangement>
+    branding: Maybe<Branding>
+    description: Maybe<Scalars['String']>
+    /** Type of flexible line, or null if line is not flexible. */
+    flexibleLineType: Maybe<Scalars['String']>
+    id: Scalars['ID']
+    journeyPatterns: Maybe<Array<Maybe<JourneyPattern>>>
+    name: Maybe<Scalars['String']>
+    notices: Array<Maybe<Notice>>
+    operator: Maybe<Operator>
+    presentation: Maybe<Presentation>
+    /** Publicly announced code for line, differentiating it from other lines for the same operator. */
+    publicCode: Maybe<Scalars['String']>
+    quays: Array<Maybe<Quay>>
+    serviceJourneys: Array<Maybe<ServiceJourney>>
+    /** Get all situations active for the line. */
+    situations: Array<Maybe<PtSituationElement>>
+    transportMode: Maybe<TransportMode>
+    transportSubmode: Maybe<TransportSubmode>
+    url: Maybe<Scalars['String']>
+}
+
+export enum Locale {
+    No = 'no',
+    Us = 'us',
+}
+
+/** Input format for specifying a location through either a place reference (id), coordinates or both. If both place and coordinates are provided the place ref will be used if found, coordinates will only be used if place is not known. */
+export type Location = {
+    /** Coordinates for the location. This can be used alone or as fallback if the place id is not found. */
+    coordinates: InputMaybe<InputCoordinates>
+    /** The name of the location. This is pass-through informationand is not used in routing. */
+    name: InputMaybe<Scalars['String']>
+    /** The id of an element in the OTP model. Currently supports Quay, StopPlace, multimodal StopPlace, and GroupOfStopPlaces. */
+    place: InputMaybe<Scalars['String']>
+}
+
+/** NOT IMPLEMENTED */
+export enum Mode {
+    Air = 'air',
+    Bicycle = 'bicycle',
+    Bus = 'bus',
+    Cableway = 'cableway',
+    Car = 'car',
+    Coach = 'coach',
+    Foot = 'foot',
+    Funicular = 'funicular',
+    Lift = 'lift',
+    Metro = 'metro',
+    Rail = 'rail',
+    Scooter = 'scooter',
+    Tram = 'tram',
+    /** Any for of public transportation */
+    Transit = 'transit',
+    Water = 'water',
+}
+
+/** Input format for specifying which modes will be allowed for this search. If this element is not present, it will default to accessMode/egressMode/directMode of foot and all transport modes will be allowed. */
+export type Modes = {
+    /** The mode used to get from the origin to the access stops in the transit network the transit network (first-mile). If the element is not present or null,only transit that can be immediately boarded from the origin will be used. */
+    accessMode: InputMaybe<StreetMode>
+    /** The mode used to get from the origin to the destination directly, without using the transit network. If the element is not present or null,direct travel without using transit will be disallowed. */
+    directMode: InputMaybe<StreetMode>
+    /** The mode used to get from the egress stops in the transit network tothe destination (last-mile). If the element is not present or null,only transit that can immediately arrive at the origin will be used. */
+    egressMode: InputMaybe<StreetMode>
+    /** The allowed modes for the transit part of the trip. Use an empty list to disallow transit for this search. If the element is not present or null, it will default to all transport modes. */
+    transportModes: InputMaybe<Array<InputMaybe<TransportModes>>>
+}
+
+export enum MultiModalMode {
+    /** Both multiModal parents and their mono modal child stop places. */
+    All = 'all',
+    /** Only mono modal children stop places, not their multi modal parent stop */
+    Child = 'child',
+    /** Multi modal parent stop places without their mono modal children. */
+    Parent = 'parent',
+}
+
+/** Text with language */
+export type MultilingualString = {
+    __typename?: 'MultilingualString'
+    language: Maybe<Scalars['String']>
+    value: Maybe<Scalars['String']>
+}
+
+export type Notice = {
+    __typename?: 'Notice'
+    id: Scalars['ID']
+    publicCode: Maybe<Scalars['String']>
+    text: Maybe<Scalars['String']>
+}
+
+/** Organisation providing public transport services. */
+export type Operator = {
+    __typename?: 'Operator'
+    id: Scalars['ID']
+    lines: Array<Maybe<Line>>
+    name: Scalars['String']
+    phone: Maybe<Scalars['String']>
+    serviceJourney: Array<Maybe<ServiceJourney>>
+    url: Maybe<Scalars['String']>
+}
+
+/** Information about pagination in a connection. */
+export type PageInfo = {
+    __typename?: 'PageInfo'
+    /** When paginating forwards, the cursor to continue. */
+    endCursor: Maybe<Scalars['String']>
+    /** When paginating forwards, are there more items? */
+    hasNextPage: Scalars['Boolean']
+    /** When paginating backwards, are there more items? */
+    hasPreviousPage: Scalars['Boolean']
+    /** When paginating backwards, the cursor to continue. */
+    startCursor: Maybe<Scalars['String']>
+}
+
+/** A series of turn by turn instructions used for walking, biking and driving. */
+export type PathGuidance = {
+    __typename?: 'PathGuidance'
+    /** This step is on an open area, such as a plaza or train platform, and thus the directions should say something like "cross" */
+    area: Maybe<Scalars['Boolean']>
+    /** The name of this street was generated by the system, so we should only display it once, and generally just display right/left directions */
+    bogusName: Maybe<Scalars['Boolean']>
+    /** The distance in meters that this step takes. */
+    distance: Maybe<Scalars['Float']>
+    /** When exiting a highway or traffic circle, the exit name/number. */
+    exit: Maybe<Scalars['String']>
+    /** The absolute direction of this step. */
+    heading: Maybe<AbsoluteDirection>
+    /** The latitude of the step. */
+    latitude: Maybe<Scalars['Float']>
+    /** The longitude of the step. */
+    longitude: Maybe<Scalars['Float']>
+    /** The relative direction of this step. */
+    relativeDirection: Maybe<RelativeDirection>
+    /** Indicates whether or not a street changes direction at an intersection. */
+    stayOn: Maybe<Scalars['Boolean']>
+    /** The name of the street. */
+    streetName: Maybe<Scalars['String']>
+}
+
+/** Common super class for all places (stop places, quays, car parks, bike parks and bike rental stations ) */
+export type Place = {
+    __typename?: 'Place'
+    /** The bike rental station related to the place */
+    bikeRentalStation: Maybe<BikeRentalStation>
+    /** The flexible area related to the place. */
+    flexibleArea: Maybe<Scalars['Coordinates']>
+    /** The latitude of the place. */
+    latitude: Scalars['Float']
+    /** The longitude of the place. */
+    longitude: Scalars['Float']
+    /** For transit quays, the name of the quay. For points of interest, the name of the POI. */
+    name: Maybe<Scalars['String']>
+    /** The quay related to the place. */
+    quay: Maybe<Quay>
+    /** The rental vehicle related to the place */
+    rentalVehicle: Maybe<RentalVehicle>
+    /** Type of vertex. (Normal, Bike sharing station, Bike P+R, Transit quay) Mostly used for better localization of bike sharing and P+R station names */
+    vertexType: Maybe<VertexType>
+}
+
+export type PlaceAtDistance = {
+    __typename?: 'PlaceAtDistance'
+    distance: Maybe<Scalars['Float']>
+    /** @deprecated Id is not referable or meaningful and will be removed */
+    id: Scalars['ID']
+    place: Maybe<PlaceInterface>
+}
+
+/** Interface for places, i.e. quays, stop places, parks */
+export type PlaceInterface = {
+    id: Scalars['ID']
+    latitude: Maybe<Scalars['Float']>
+    longitude: Maybe<Scalars['Float']>
+}
+
+/** A list of coordinates encoded as a polyline string (see http://code.google.com/apis/maps/documentation/polylinealgorithm.html) */
+export type PointsOnLink = {
+    __typename?: 'PointsOnLink'
+    /** The number of points in the string */
+    length: Maybe<Scalars['Int']>
+    /** The encoded points of the polyline. Be aware that the string could contain escape characters that need to be accounted for. (https://www.freeformatter.com/javascript-escape.html) */
+    points: Maybe<Scalars['String']>
+}
+
+/** Types describing common presentation properties */
+export type Presentation = {
+    __typename?: 'Presentation'
+    colour: Maybe<Scalars['String']>
+    textColour: Maybe<Scalars['String']>
+}
+
+/** Simple public transport situation element */
+export type PtSituationElement = {
+    __typename?: 'PtSituationElement'
+    /** Advice of situation in all different translations available */
+    advice: Array<MultilingualString>
+    /** Get affected authority for this situation element */
+    authority: Maybe<Authority>
+    /** Description of situation in all different translations available */
+    description: Array<MultilingualString>
+    id: Scalars['ID']
+    /** Optional links to more information. */
+    infoLinks: Maybe<Array<Maybe<InfoLink>>>
+    lines: Array<Maybe<Line>>
+    /** Priority of this situation  */
+    priority: Maybe<Scalars['Int']>
+    quays: Array<Maybe<Quay>>
+    /**
+     * Authority that reported this situation
+     * @deprecated Not yet officially supported. May be removed or renamed.
+     */
+    reportAuthority: Maybe<Authority>
+    /** ReportType of this situation */
+    reportType: Maybe<ReportType>
+    serviceJourneys: Array<Maybe<ServiceJourney>>
+    /** Severity of this situation  */
+    severity: Maybe<Severity>
+    /** Operator's internal id for this situation */
+    situationNumber: Maybe<Scalars['String']>
+    /** Summary of situation in all different translations available */
+    summary: Array<MultilingualString>
+    /** Period this situation is in effect */
+    validityPeriod: Maybe<ValidityPeriod>
+}
+
+export enum PurchaseWhen {
+    AdvanceAndDayOfTravel = 'advanceAndDayOfTravel',
+    DayOfTravelOnly = 'dayOfTravelOnly',
+    Other = 'other',
+    TimeOfTravelOnly = 'timeOfTravelOnly',
+    UntilPreviousDay = 'untilPreviousDay',
+}
+
+/** A place such as platform, stance, or quayside where passengers have access to PT vehicles. */
+export type Quay = PlaceInterface & {
+    __typename?: 'Quay'
+    description: Maybe<Scalars['String']>
+    /** List of visits to this quay as part of vehicle journeys. */
+    estimatedCalls: Array<EstimatedCall>
+    id: Scalars['ID']
+    /** List of journey patterns servicing this quay */
+    journeyPatterns: Array<Maybe<JourneyPattern>>
+    latitude: Maybe<Scalars['Float']>
+    /** List of lines servicing this quay */
+    lines: Array<Line>
+    longitude: Maybe<Scalars['Float']>
+    name: Scalars['String']
+    /** Public code used to identify this quay within the stop place. For instance a platform code. */
+    publicCode: Maybe<Scalars['String']>
+    /** Get all situations active for the quay. */
+    situations: Array<Maybe<PtSituationElement>>
+    /** The stop place to which this quay belongs to. */
+    stopPlace: Maybe<StopPlace>
+    tariffZones: Array<Maybe<TariffZone>>
+    /** Whether this quay is suitable for wheelchair boarding. */
+    wheelchairAccessible: Maybe<WheelchairBoarding>
+}
+
+/** A place such as platform, stance, or quayside where passengers have access to PT vehicles. */
+export type QuayEstimatedCallsArgs = {
+    arrivalDeparture?: InputMaybe<ArrivalDeparture>
+    includeCancelledTrips?: InputMaybe<Scalars['Boolean']>
+    numberOfDepartures?: InputMaybe<Scalars['Int']>
+    numberOfDeparturesPerLineAndDestinationDisplay?: InputMaybe<Scalars['Int']>
+    omitNonBoarding?: InputMaybe<Scalars['Boolean']>
+    startTime?: InputMaybe<Scalars['DateTime']>
+    timeRange?: InputMaybe<Scalars['Int']>
+    whiteListed?: InputMaybe<InputWhiteListed>
+    whiteListedModes?: InputMaybe<Array<InputMaybe<TransportMode>>>
+}
+
+export type QuayAtDistance = {
+    __typename?: 'QuayAtDistance'
+    /** The distance in meters to the given quay. */
+    distance: Maybe<Scalars['Float']>
+    id: Scalars['ID']
+    quay: Maybe<Quay>
+}
+
+export type QueryType = {
+    __typename?: 'QueryType'
+    /** Get all authorities */
+    authorities: Array<Maybe<Authority>>
+    /** Get an authority by ID */
+    authority: Maybe<Authority>
+    /** Get a single bike park based on its id */
+    bikePark: Maybe<BikePark>
+    /** Get all bike parks */
+    bikeParks: Array<Maybe<BikePark>>
+    /** Get all bike rental stations */
+    bikeRentalStation: Maybe<BikeRentalStation>
+    /** Get all bike rental stations */
+    bikeRentalStations: Array<Maybe<BikeRentalStation>>
+    /** Get all bike rental stations within the specified bounding box. */
+    bikeRentalStationsByBbox: Array<Maybe<BikeRentalStation>>
+    /** Get a single line based on its id */
+    line: Maybe<Line>
+    /** Get all lines */
+    lines: Array<Maybe<Line>>
+    /** Get all places (quays, stop places, car parks etc. with coordinates) within the specified radius from a location. The returned type has two fields place and distance. The search is done by walking so the distance is according to the network of walkables. */
+    nearest: Maybe<PlaceAtDistanceConnection>
+    /** Get a operator by ID */
+    operator: Maybe<Operator>
+    /** Get all operators */
+    operators: Array<Maybe<Operator>>
+    /** Get a single quay based on its id) */
+    quay: Maybe<Quay>
+    /** Get all quays */
+    quays: Array<Maybe<Quay>>
+    /** Get all quays within the specified bounding box */
+    quaysByBbox: Array<Maybe<Quay>>
+    /** Get all quays within the specified walking radius from a location. The returned type has two fields quay and distance */
+    quaysByRadius: Maybe<QuayAtDistanceConnection>
+    /** Get default routing parameters. */
+    routingParameters: Maybe<RoutingParameters>
+    /** Get OTP server information */
+    serverInfo: ServerInfo
+    /** Get a single service journey based on its id */
+    serviceJourney: Maybe<ServiceJourney>
+    /** Get all service journeys */
+    serviceJourneys: Array<Maybe<ServiceJourney>>
+    /** Get a single situation based on its situationNumber */
+    situation: Maybe<PtSituationElement>
+    /** Get all active situations. */
+    situations: Array<Maybe<PtSituationElement>>
+    /** Get a single stopPlace based on its id) */
+    stopPlace: Maybe<StopPlace>
+    /** Get all stopPlaces */
+    stopPlaces: Array<Maybe<StopPlace>>
+    /** Get all stop places within the specified bounding box */
+    stopPlacesByBbox: Array<Maybe<StopPlace>>
+    /** Input type for executing a travel search for a trip between two locations. Returns trip patterns describing suggested alternatives for the trip. */
+    trip: Trip
+}
+
+export type QueryTypeAuthorityArgs = {
+    id: Scalars['String']
+}
+
+export type QueryTypeBikeParkArgs = {
+    id: Scalars['String']
+}
+
+export type QueryTypeBikeRentalStationArgs = {
+    id: Scalars['String']
+}
+
+export type QueryTypeBikeRentalStationsArgs = {
+    ids?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+}
+
+export type QueryTypeBikeRentalStationsByBboxArgs = {
+    maximumLatitude?: InputMaybe<Scalars['Float']>
+    maximumLongitude?: InputMaybe<Scalars['Float']>
+    minimumLatitude?: InputMaybe<Scalars['Float']>
+    minimumLongitude?: InputMaybe<Scalars['Float']>
+}
+
+export type QueryTypeLineArgs = {
+    id: Scalars['ID']
+}
+
+export type QueryTypeLinesArgs = {
+    authorities?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+    flexibleOnly?: InputMaybe<Scalars['Boolean']>
+    ids?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>
+    name?: InputMaybe<Scalars['String']>
+    publicCode?: InputMaybe<Scalars['String']>
+    publicCodes?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+    transportModes?: InputMaybe<Array<InputMaybe<TransportMode>>>
+}
+
+export type QueryTypeNearestArgs = {
+    after?: InputMaybe<Scalars['String']>
+    before?: InputMaybe<Scalars['String']>
+    filterByIds?: InputMaybe<InputPlaceIds>
+    filterByInUse?: InputMaybe<Scalars['Boolean']>
+    filterByModes?: InputMaybe<Array<InputMaybe<TransportMode>>>
+    filterByPlaceTypes?: InputMaybe<Array<InputMaybe<FilterPlaceType>>>
+    first?: InputMaybe<Scalars['Int']>
+    last?: InputMaybe<Scalars['Int']>
+    latitude: Scalars['Float']
+    longitude: Scalars['Float']
+    maximumDistance?: Scalars['Float']
+    maximumResults?: InputMaybe<Scalars['Int']>
+    multiModalMode?: InputMaybe<MultiModalMode>
+}
+
+export type QueryTypeOperatorArgs = {
+    id: Scalars['String']
+}
+
+export type QueryTypeQuayArgs = {
+    id: Scalars['String']
+}
+
+export type QueryTypeQuaysArgs = {
+    ids?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+    name?: InputMaybe<Scalars['String']>
+}
+
+export type QueryTypeQuaysByBboxArgs = {
+    authority?: InputMaybe<Scalars['String']>
+    filterByInUse?: InputMaybe<Scalars['Boolean']>
+    maximumLatitude: Scalars['Float']
+    maximumLongitude: Scalars['Float']
+    minimumLatitude: Scalars['Float']
+    minimumLongitude: Scalars['Float']
+}
+
+export type QueryTypeQuaysByRadiusArgs = {
+    after?: InputMaybe<Scalars['String']>
+    authority?: InputMaybe<Scalars['String']>
+    before?: InputMaybe<Scalars['String']>
+    first?: InputMaybe<Scalars['Int']>
+    last?: InputMaybe<Scalars['Int']>
+    latitude: Scalars['Float']
+    longitude: Scalars['Float']
+    radius: Scalars['Float']
+}
+
+export type QueryTypeServiceJourneyArgs = {
+    id: Scalars['String']
+}
+
+export type QueryTypeServiceJourneysArgs = {
+    activeDates?: InputMaybe<Array<InputMaybe<Scalars['Date']>>>
+    authorities?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+    lines?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>
+    privateCodes?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+}
+
+export type QueryTypeSituationArgs = {
+    situationNumber: Scalars['String']
+}
+
+export type QueryTypeSituationsArgs = {
+    authorities?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+    severities?: InputMaybe<Array<InputMaybe<Severity>>>
+}
+
+export type QueryTypeStopPlaceArgs = {
+    id: Scalars['String']
+}
+
+export type QueryTypeStopPlacesArgs = {
+    ids?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+}
+
+export type QueryTypeStopPlacesByBboxArgs = {
+    authority?: InputMaybe<Scalars['String']>
+    filterByInUse?: InputMaybe<Scalars['Boolean']>
+    maximumLatitude: Scalars['Float']
+    maximumLongitude: Scalars['Float']
+    minimumLatitude: Scalars['Float']
+    minimumLongitude: Scalars['Float']
+    multiModalMode?: InputMaybe<MultiModalMode>
+}
+
+export type QueryTypeTripArgs = {
+    alightSlackDefault?: InputMaybe<Scalars['Int']>
+    alightSlackList?: InputMaybe<Array<InputMaybe<TransportModeSlack>>>
+    arriveBy?: InputMaybe<Scalars['Boolean']>
+    banned?: InputMaybe<InputBanned>
+    bicycleOptimisationMethod?: InputMaybe<BicycleOptimisationMethod>
+    bikeSpeed?: InputMaybe<Scalars['Float']>
+    boardSlackDefault?: InputMaybe<Scalars['Int']>
+    boardSlackList?: InputMaybe<Array<InputMaybe<TransportModeSlack>>>
+    dateTime?: InputMaybe<Scalars['DateTime']>
+    debugItineraryFilter?: InputMaybe<Scalars['Boolean']>
+    extraSearchCoachReluctance?: InputMaybe<Scalars['Float']>
+    from: Location
+    ignoreRealtimeUpdates?: InputMaybe<Scalars['Boolean']>
+    includePlannedCancellations?: InputMaybe<Scalars['Boolean']>
+    itineraryFilters?: InputMaybe<ItineraryFilters>
+    locale?: InputMaybe<Locale>
+    maximumTransfers?: InputMaybe<Scalars['Int']>
+    modes?: InputMaybe<Modes>
+    numTripPatterns?: InputMaybe<Scalars['Int']>
+    pageCursor?: InputMaybe<Scalars['String']>
+    searchWindow?: InputMaybe<Scalars['Int']>
+    timetableView?: InputMaybe<Scalars['Boolean']>
+    to: Location
+    transferPenalty?: InputMaybe<Scalars['Int']>
+    transferSlack?: InputMaybe<Scalars['Int']>
+    transitGeneralizedCostLimit?: InputMaybe<Scalars['DoubleFunction']>
+    triangleFactors?: InputMaybe<TriangleFactors>
+    useBikeRentalAvailabilityInformation?: InputMaybe<Scalars['Boolean']>
+    waitReluctance?: InputMaybe<Scalars['Float']>
+    walkReluctance?: InputMaybe<Scalars['Float']>
+    walkSpeed?: InputMaybe<Scalars['Float']>
+    wheelchairAccessible?: InputMaybe<Scalars['Boolean']>
+    whiteListed?: InputMaybe<InputWhiteListed>
+}
+
+export enum RealtimeState {
+    /** The service journey has been added using a real-time update, i.e. the service journey was not present in the regular time table. */
+    Added = 'Added',
+    /** The service journey has been canceled by a real-time update. */
+    Canceled = 'canceled',
+    /** The service journey information has been updated and resulted in a different journey pattern compared to the journey pattern of the scheduled service journey. */
+    Modified = 'modified',
+    /** The service journey information comes from the regular time table, i.e. no real-time update has been applied. */
+    Scheduled = 'scheduled',
+    /** The service journey information has been updated, but the journey pattern stayed the same as the journey pattern of the scheduled service journey. */
+    Updated = 'updated',
+}
+
+export enum RelativeDirection {
+    CircleClockwise = 'circleClockwise',
+    CircleCounterclockwise = 'circleCounterclockwise',
+    Continue = 'continue',
+    Depart = 'depart',
+    Elevator = 'elevator',
+    HardLeft = 'hardLeft',
+    HardRight = 'hardRight',
+    Left = 'left',
+    Right = 'right',
+    SlightlyLeft = 'slightlyLeft',
+    SlightlyRight = 'slightlyRight',
+    UturnLeft = 'uturnLeft',
+    UturnRight = 'uturnRight',
+}
+
+export type RentalVehicle = PlaceInterface & {
+    __typename?: 'RentalVehicle'
+    currentRangeMeters: Maybe<Scalars['Float']>
+    id: Scalars['ID']
+    latitude: Scalars['Float']
+    longitude: Scalars['Float']
+    network: Scalars['String']
+    vehicleType: RentalVehicleType
+}
+
+export type RentalVehicleType = {
+    __typename?: 'RentalVehicleType'
+    formFactor: Scalars['String']
+    maxRangeMeters: Maybe<Scalars['Float']>
+    name: Maybe<Scalars['String']>
+    propulsionType: Scalars['String']
+    vehicleTypeId: Scalars['String']
+}
+
+export enum ReportType {
+    /** Indicates a general info-message that should not affect trip. */
+    General = 'general',
+    /** Indicates an incident that may affect trip. */
+    Incident = 'incident',
+}
+
+/** Description of the reason, why the planner did not return any results */
+export type RoutingError = {
+    __typename?: 'RoutingError'
+    /** An enum describing the reason */
+    code: RoutingErrorCode
+    /** A textual description of why the search failed. The clients are expected to have their own translations based on the code, for user visible error messages. */
+    description: Scalars['String']
+    /** An enum describing the field which should be changed, in order for the search to succeed */
+    inputField: Maybe<InputField>
+}
+
+export enum RoutingErrorCode {
+    /** The specified location is not close to any streets or transit stops */
+    LocationNotFound = 'locationNotFound',
+    /** No stops are reachable from the location specified. You can try searching using a different access or egress mode */
+    NoStopsInRange = 'noStopsInRange',
+    /** No transit connection was found between the origin and destination withing the operating day or the next day */
+    NoTransitConnection = 'noTransitConnection',
+    /** Transit connection was found, but it was outside the search window, see metadata for the next search window */
+    NoTransitConnectionInSearchWindow = 'noTransitConnectionInSearchWindow',
+    /** The coordinates are outside the bounds of the data currently loaded into the system */
+    OutsideBounds = 'outsideBounds',
+    /** The date specified is outside the range of data currently loaded into the system */
+    OutsideServicePeriod = 'outsideServicePeriod',
+    /** An unknown error happened during the search. The details have been logged to the server logs */
+    SystemError = 'systemError',
+    /** The origin and destination are so close to each other, that walking is always better, but no direct mode was specified for the search */
+    WalkingBetterThanTransit = 'walkingBetterThanTransit',
+}
+
+/** The default parameters used in travel searches. */
+export type RoutingParameters = {
+    __typename?: 'RoutingParameters'
+    /** The alightSlack is the minimum extra time after exiting a public transport vehicle. This is the default value used, if not overridden by the 'alightSlackList'. */
+    alightSlackDefault: Maybe<Scalars['Int']>
+    /** List of alightSlack for a given set of modes. */
+    alightSlackList: Maybe<Array<Maybe<TransportModeSlackType>>>
+    /** @deprecated Rental is specified by modes */
+    allowBikeRental: Maybe<Scalars['Boolean']>
+    /** Separate cost for boarding a vehicle with a bicycle, which is more difficult than on foot. */
+    bikeBoardCost: Maybe<Scalars['Int']>
+    /** Cost to park a bike. */
+    bikeParkCost: Maybe<Scalars['Int']>
+    /** Time to park a bike. */
+    bikeParkTime: Maybe<Scalars['Int']>
+    /** Cost to drop-off a rented bike. */
+    bikeRentalDropOffCost: Maybe<Scalars['Int']>
+    /** Time to drop-off a rented bike. */
+    bikeRentalDropOffTime: Maybe<Scalars['Int']>
+    /** Cost to rent a bike. */
+    bikeRentalPickupCost: Maybe<Scalars['Int']>
+    /** Time to rent a bike. */
+    bikeRentalPickupTime: Maybe<Scalars['Int']>
+    /** Max bike speed along streets, in meters per second */
+    bikeSpeed: Maybe<Scalars['Float']>
+    /** The boardSlack is the minimum extra time to board a public transport vehicle. This is the same as the 'minimumTransferTime', except that this also apply to to the first transit leg in the trip. This is the default value used, if not overridden by the 'boardSlackList'. */
+    boardSlackDefault: Maybe<Scalars['Int']>
+    /** List of boardSlack for a given set of modes. */
+    boardSlackList: Maybe<Array<Maybe<TransportModeSlackType>>>
+    /** The acceleration speed of an automobile, in meters per second per second. */
+    carAccelerationSpeed: Maybe<Scalars['Float']>
+    /** The deceleration speed of an automobile, in meters per second per second. */
+    carDecelerationSpeed: Maybe<Scalars['Float']>
+    /** Time to park a car in a park and ride, w/o taking into account driving and walking cost. */
+    carDropOffTime: Maybe<Scalars['Int']>
+    /** Max car speed along streets, in meters per second */
+    carSpeed: Maybe<Scalars['Float']>
+    /** @deprecated NOT IN USE IN OTP2. */
+    compactLegsByReversedSearch: Maybe<Scalars['Boolean']>
+    debugItineraryFilter: Maybe<Scalars['Boolean']>
+    /** Option to disable the default filtering of GTFS-RT alerts by time. */
+    disableAlertFiltering: Maybe<Scalars['Boolean']>
+    /** If true, the remaining weight heuristic is disabled. */
+    disableRemainingWeightHeuristic: Maybe<Scalars['Boolean']>
+    /** What is the cost of boarding a elevator? */
+    elevatorBoardCost: Maybe<Scalars['Int']>
+    /** How long does it take to get on an elevator, on average. */
+    elevatorBoardTime: Maybe<Scalars['Int']>
+    /** What is the cost of travelling one floor on an elevator? */
+    elevatorHopCost: Maybe<Scalars['Int']>
+    /** How long does it take to advance one floor on an elevator? */
+    elevatorHopTime: Maybe<Scalars['Int']>
+    /** Whether to apply the ellipsoid->geoid offset to all elevations in the response. */
+    geoIdElevation: Maybe<Scalars['Boolean']>
+    /** When true, realtime updates are ignored during this search. */
+    ignoreRealTimeUpdates: Maybe<Scalars['Boolean']>
+    /** When true, service journeys cancelled in scheduled route data will be included during this search. */
+    includedPlannedCancellations: Maybe<Scalars['Boolean']>
+    kissAndRide: Maybe<Scalars['Boolean']>
+    /** This is the maximum duration in seconds for a direct street search. This is a performance limit and should therefore be set high. Use filters to limit what is presented to the client. */
+    maxDirectStreetDuration: Maybe<Scalars['Float']>
+    /** The maximum slope of streets for wheelchair trips. */
+    maxSlope: Maybe<Scalars['Float']>
+    /** Maximum number of transfers returned in a trip plan. */
+    maxTransfers: Maybe<Scalars['Int']>
+    /** The maximum number of itineraries to return. */
+    numItineraries: Maybe<Scalars['Int']>
+    /** Accept only paths that use transit (no street-only paths). */
+    onlyTransitTrips: Maybe<Scalars['Boolean']>
+    /** Penalty added for using every route that is not preferred if user set any route as preferred. We return number of seconds that we are willing to wait for preferred route. */
+    otherThanPreferredRoutesPenalty: Maybe<Scalars['Int']>
+    parkAndRide: Maybe<Scalars['Boolean']>
+    /** @deprecated NOT IN USE IN OTP2. */
+    reverseOptimizeOnTheFly: Maybe<Scalars['Boolean']>
+    /** Whether the planner should return intermediate stops lists for transit legs. */
+    showIntermediateStops: Maybe<Scalars['Boolean']>
+    /** Used instead of walkReluctance for stairs. */
+    stairsReluctance: Maybe<Scalars['Float']>
+    /** An extra penalty added on transfers (i.e. all boardings except the first one). */
+    transferPenalty: Maybe<Scalars['Int']>
+    /** A global minimum transfer time (in seconds) that specifies the minimum amount of time that must pass between exiting one transit vehicle and boarding another. */
+    transferSlack: Maybe<Scalars['Int']>
+    /** Multiplicative factor on expected turning time. */
+    turnReluctance: Maybe<Scalars['Float']>
+    /** How much less bad is waiting at the beginning of the trip (replaces waitReluctance on the first boarding). */
+    waitAtBeginningFactor: Maybe<Scalars['Float']>
+    /** How much worse is waiting for a transit vehicle than being on a transit vehicle, as a multiplier. */
+    waitReluctance: Maybe<Scalars['Float']>
+    /** This prevents unnecessary transfers by adding a cost for boarding a vehicle. */
+    walkBoardCost: Maybe<Scalars['Int']>
+    /** A multiplier for how bad walking is, compared to being in transit for equal lengths of time. */
+    walkReluctance: Maybe<Scalars['Float']>
+    /** Max walk speed along streets, in meters per second */
+    walkSpeed: Maybe<Scalars['Float']>
+    /** Whether the trip must be wheelchair accessible. */
+    wheelChairAccessible: Maybe<Scalars['Boolean']>
+}
+
+export type ServerInfo = {
+    __typename?: 'ServerInfo'
+    /** The 'configVersion' of the build-config.json file. */
+    buildConfigVersion: Maybe<Scalars['String']>
+    /** OTP Build timestamp */
+    buildTime: Maybe<Scalars['String']>
+    gitBranch: Maybe<Scalars['String']>
+    gitCommit: Maybe<Scalars['String']>
+    gitCommitTime: Maybe<Scalars['String']>
+    /** The 'configVersion' of the otp-config.json file. */
+    otpConfigVersion: Maybe<Scalars['String']>
+    /** The otp-serialization-version-id used to check graphs for compatibility with current version of OTP. */
+    otpSerializationVersionId: Maybe<Scalars['String']>
+    /** The 'configVersion' of the router-config.json file. */
+    routerConfigVersion: Maybe<Scalars['String']>
+    /** Maven version */
+    version: Maybe<Scalars['String']>
+}
+
+export enum ServiceAlteration {
+    Cancellation = 'cancellation',
+    ExtraJourney = 'extraJourney',
+    Planned = 'planned',
+    Replaced = 'replaced',
+}
+
+/** A planned vehicle journey with passengers. */
+export type ServiceJourney = {
+    __typename?: 'ServiceJourney'
+    activeDates: Array<Maybe<Scalars['Date']>>
+    /** Whether bikes are allowed on service journey. */
+    bikesAllowed: Maybe<BikesAllowed>
+    /**
+     * Booking arrangements for flexible services.
+     * @deprecated BookingArrangements are defined per stop, and can be found under `passingTimes` or `estimatedCalls`
+     */
+    bookingArrangements: Maybe<BookingArrangement>
+    directionType: Maybe<DirectionType>
+    /** Returns scheduled passingTimes for this ServiceJourney for a given date, updated with realtime-updates (if available). NB! This takes a date as argument (default=today) and returns estimatedCalls for that date and should only be used if the date is known when creating the request. For fetching estimatedCalls for a given trip.leg, use leg.serviceJourneyEstimatedCalls instead. */
+    estimatedCalls: Maybe<Array<Maybe<EstimatedCall>>>
+    id: Scalars['ID']
+    journeyPattern: Maybe<JourneyPattern>
+    line: Line
+    notices: Array<Maybe<Notice>>
+    operator: Maybe<Operator>
+    /** Returns scheduled passing times only - without realtime-updates, for realtime-data use 'estimatedCalls' */
+    passingTimes: Array<Maybe<TimetabledPassingTime>>
+    /** Detailed path travelled by service journey. Not available for flexible trips. */
+    pointsOnLink: Maybe<PointsOnLink>
+    /** For internal use by operators. */
+    privateCode: Maybe<Scalars['String']>
+    /** Publicly announced code for service journey, differentiating it from other service journeys for the same line. */
+    publicCode: Maybe<Scalars['String']>
+    /** Quays visited by service journey */
+    quays: Array<Quay>
+    /** @deprecated The service journey alteration will be moved out of SJ and grouped together with the SJ and date. In Netex this new type is called DatedServiceJourney. We will create artificial DSJs for the old SJs. */
+    serviceAlteration: Maybe<ServiceAlteration>
+    /** Get all situations active for the service journey. */
+    situations: Array<Maybe<PtSituationElement>>
+    transportMode: Maybe<TransportMode>
+    transportSubmode: Maybe<TransportSubmode>
+    /** Whether service journey is accessible with wheelchair. */
+    wheelchairAccessible: Maybe<WheelchairBoarding>
+}
+
+/** A planned vehicle journey with passengers. */
+export type ServiceJourneyEstimatedCallsArgs = {
+    date?: InputMaybe<Scalars['Date']>
+}
+
+/** A planned vehicle journey with passengers. */
+export type ServiceJourneyQuaysArgs = {
+    first?: InputMaybe<Scalars['Int']>
+    last?: InputMaybe<Scalars['Int']>
+}
+
+export enum Severity {
+    /** Situation has no impact on trips. */
+    NoImpact = 'noImpact',
+    /** Situation has an impact on trips (default). */
+    Normal = 'normal',
+    /** Situation has a severe impact on trips. */
+    Severe = 'severe',
+    /** Situation has a slight impact on trips. */
+    Slight = 'slight',
+    /** Severity is undefined. */
+    Undefined = 'undefined',
+    /** Situation has unknown impact on trips. */
+    Unknown = 'unknown',
+    /** Situation has a very severe impact on trips. */
+    VerySevere = 'verySevere',
+    /** Situation has a very slight impact on trips. */
+    VerySlight = 'verySlight',
+}
+
+/** Named place where public transport may be accessed. May be a building complex (e.g. a station) or an on-street location. */
+export type StopPlace = PlaceInterface & {
+    __typename?: 'StopPlace'
+    description: Maybe<Scalars['String']>
+    /** List of visits to this stop place as part of vehicle journeys. */
+    estimatedCalls: Array<EstimatedCall>
+    id: Scalars['ID']
+    latitude: Maybe<Scalars['Float']>
+    longitude: Maybe<Scalars['Float']>
+    name: Scalars['String']
+    /** Returns parent stop for this stop */
+    parent: Maybe<StopPlace>
+    /** Returns all quays that are children of this stop place */
+    quays: Maybe<Array<Maybe<Quay>>>
+    tariffZones: Array<Maybe<TariffZone>>
+    /** The transport modes of quays under this stop place. */
+    transportMode: Maybe<Array<Maybe<TransportMode>>>
+    /** The transport submode serviced by this stop place. */
+    transportSubmode: Maybe<Array<Maybe<TransportSubmode>>>
+    /** Relative weighting of this stop with regards to interchanges. NOT IMPLEMENTED */
+    weighting: Maybe<InterchangeWeighting>
+}
+
+/** Named place where public transport may be accessed. May be a building complex (e.g. a station) or an on-street location. */
+export type StopPlaceEstimatedCallsArgs = {
+    arrivalDeparture?: InputMaybe<ArrivalDeparture>
+    includeCancelledTrips?: InputMaybe<Scalars['Boolean']>
+    numberOfDepartures?: InputMaybe<Scalars['Int']>
+    numberOfDeparturesPerLineAndDestinationDisplay?: InputMaybe<Scalars['Int']>
+    startTime?: InputMaybe<Scalars['DateTime']>
+    timeRange?: InputMaybe<Scalars['Int']>
+    whiteListed?: InputMaybe<InputWhiteListed>
+    whiteListedModes?: InputMaybe<Array<InputMaybe<TransportMode>>>
+}
+
+/** Named place where public transport may be accessed. May be a building complex (e.g. a station) or an on-street location. */
+export type StopPlaceQuaysArgs = {
+    filterByInUse?: InputMaybe<Scalars['Boolean']>
+}
+
+export enum StreetMode {
+    /** Bike only. This can be used as access/egress, but transfers will still be walk only. */
+    Bicycle = 'bicycle',
+    /** Bike to a bike parking area, then walk the rest of the way. Direct mode and access mode only. */
+    BikePark = 'bike_park',
+    /** Walk to a bike rental point, bike to a bike rental drop-off point, and walk the rest of the way. This can include bike rental at fixed locations or free-floating services. */
+    BikeRental = 'bike_rental',
+    /** Car only. Direct mode only. */
+    Car = 'car',
+    /** Start in the car, drive to a parking area, and walk the rest of the way. Direct mode and access mode only. */
+    CarPark = 'car_park',
+    /** Walk to a pickup point along the road, drive to a drop-off point along the road, and walk the rest of the way. This can include various taxi-services or kiss & ride. */
+    CarPickup = 'car_pickup',
+    /** Walk to an eligible pickup area for flexible transportation, ride to an eligible drop-off area and then walk the rest of the way. */
+    Flexible = 'flexible',
+    /** Walk only */
+    Foot = 'foot',
+    /** Walk to a scooter rental point, ride a scooter to a scooter rental drop-off point, and walk the rest of the way. This can include scooter rental at fixed locations or free-floating services. */
+    ScooterRental = 'scooter_rental',
+}
+
+/** A system notice is used to tag elements with system information for debugging or other system related purpose. One use-case is to run a routing search with 'itineraryFilters.debug: true'. This will then tag itineraries instead of removing them from the result. This make it possible to inspect the itinerary-filter-chain. A SystemNotice only have english text, because the primary user are technical staff, like testers and developers. */
+export type SystemNotice = {
+    __typename?: 'SystemNotice'
+    tag: Maybe<Scalars['String']>
+    text: Maybe<Scalars['String']>
+}
+
+export type TariffZone = {
+    __typename?: 'TariffZone'
+    id: Scalars['ID']
+    name: Maybe<Scalars['String']>
+}
+
+export type TimeAndDayOffset = {
+    __typename?: 'TimeAndDayOffset'
+    /** Number of days offset from base line time */
+    dayOffset: Maybe<Scalars['Int']>
+    /** Local time */
+    time: Maybe<Scalars['Time']>
+}
+
+/** Scheduled passing times. These are not affected by real time updates. */
+export type TimetabledPassingTime = {
+    __typename?: 'TimetabledPassingTime'
+    /** Scheduled time of arrival at quay */
+    arrival: Maybe<TimeAndDayOffset>
+    /** Booking arrangements for this passing time. */
+    bookingArrangements: Maybe<BookingArrangement>
+    /** Scheduled time of departure from quay */
+    departure: Maybe<TimeAndDayOffset>
+    destinationDisplay: Maybe<DestinationDisplay>
+    /** Whether vehicle may be alighted at quay. */
+    forAlighting: Maybe<Scalars['Boolean']>
+    /** Whether vehicle may be boarded at quay. */
+    forBoarding: Maybe<Scalars['Boolean']>
+    notices: Array<Maybe<Notice>>
+    quay: Maybe<Quay>
+    /** Whether vehicle will only stop on request. */
+    requestStop: Maybe<Scalars['Boolean']>
+    serviceJourney: Maybe<ServiceJourney>
+    /** Whether this is a timing point or not. Boarding and alighting is not allowed at timing points. */
+    timingPoint: Maybe<Scalars['Boolean']>
+}
+
+export enum TransportMode {
+    Air = 'air',
+    Bus = 'bus',
+    Cableway = 'cableway',
+    Coach = 'coach',
+    Funicular = 'funicular',
+    Lift = 'lift',
+    Metro = 'metro',
+    Monorail = 'monorail',
+    Rail = 'rail',
+    Tram = 'tram',
+    Trolleybus = 'trolleybus',
+    Unknown = 'unknown',
+    Water = 'water',
+}
+
+/** Used to specify board and alight slack for a given modes. */
+export type TransportModeSlack = {
+    /** List of modes for which the given slack apply. */
+    modes: Array<TransportMode>
+    /** The slack used for all given modes. */
+    slack: Scalars['Int']
+}
+
+/** Used to specify board and alight slack for a given modes. */
+export type TransportModeSlackType = {
+    __typename?: 'TransportModeSlackType'
+    modes: Array<TransportMode>
+    slack: Scalars['Int']
+}
+
+export type TransportModes = {
+    /** A transportMode that should be allowed for this search. You can furthernarrow it down by specifying a list of transportSubModes */
+    transportMode: InputMaybe<TransportMode>
+    /** The allowed transportSubModes for this search. If this element is notpresent or null, it will default to all transportSubModes for the specifiedTransportMode. Be aware that all transportSubModes have an associated TransportMode, which must match what is specified in the transportMode field. */
+    transportSubModes: InputMaybe<Array<InputMaybe<TransportSubmode>>>
+}
+
+export enum TransportSubmode {
+    SchengenAreaFlight = 'SchengenAreaFlight',
+    AirportBoatLink = 'airportBoatLink',
+    AirportLinkBus = 'airportLinkBus',
+    AirportLinkRail = 'airportLinkRail',
+    AirshipService = 'airshipService',
+    AllFunicularServices = 'allFunicularServices',
+    AllHireVehicles = 'allHireVehicles',
+    AllTaxiServices = 'allTaxiServices',
+    BikeTaxi = 'bikeTaxi',
+    BlackCab = 'blackCab',
+    CableCar = 'cableCar',
+    CableFerry = 'cableFerry',
+    CanalBarge = 'canalBarge',
+    CarTransportRailService = 'carTransportRailService',
+    ChairLift = 'chairLift',
+    CharterTaxi = 'charterTaxi',
+    CityTram = 'cityTram',
+    CommunalTaxi = 'communalTaxi',
+    CommuterCoach = 'commuterCoach',
+    CrossCountryRail = 'crossCountryRail',
+    DedicatedLaneBus = 'dedicatedLaneBus',
+    DemandAndResponseBus = 'demandAndResponseBus',
+    DomesticCharterFlight = 'domesticCharterFlight',
+    DomesticFlight = 'domesticFlight',
+    DomesticScheduledFlight = 'domesticScheduledFlight',
+    DragLift = 'dragLift',
+    ExpressBus = 'expressBus',
+    Funicular = 'funicular',
+    HelicopterService = 'helicopterService',
+    HighFrequencyBus = 'highFrequencyBus',
+    HighSpeedPassengerService = 'highSpeedPassengerService',
+    HighSpeedRail = 'highSpeedRail',
+    HighSpeedVehicleService = 'highSpeedVehicleService',
+    HireCar = 'hireCar',
+    HireCycle = 'hireCycle',
+    HireMotorbike = 'hireMotorbike',
+    HireVan = 'hireVan',
+    IntercontinentalCharterFlight = 'intercontinentalCharterFlight',
+    IntercontinentalFlight = 'intercontinentalFlight',
+    International = 'international',
+    InternationalCarFerry = 'internationalCarFerry',
+    InternationalCharterFlight = 'internationalCharterFlight',
+    InternationalCoach = 'internationalCoach',
+    InternationalFlight = 'internationalFlight',
+    InternationalPassengerFerry = 'internationalPassengerFerry',
+    InterregionalRail = 'interregionalRail',
+    Lift = 'lift',
+    Local = 'local',
+    LocalBus = 'localBus',
+    LocalCarFerry = 'localCarFerry',
+    LocalPassengerFerry = 'localPassengerFerry',
+    LocalTram = 'localTram',
+    LongDistance = 'longDistance',
+    Metro = 'metro',
+    MiniCab = 'miniCab',
+    MobilityBus = 'mobilityBus',
+    MobilityBusForRegisteredDisabled = 'mobilityBusForRegisteredDisabled',
+    NationalCarFerry = 'nationalCarFerry',
+    NationalCoach = 'nationalCoach',
+    NationalPassengerFerry = 'nationalPassengerFerry',
+    NightBus = 'nightBus',
+    NightRail = 'nightRail',
+    PostBoat = 'postBoat',
+    PostBus = 'postBus',
+    RackAndPinionRailway = 'rackAndPinionRailway',
+    RailReplacementBus = 'railReplacementBus',
+    RailShuttle = 'railShuttle',
+    RailTaxi = 'railTaxi',
+    RegionalBus = 'regionalBus',
+    RegionalCarFerry = 'regionalCarFerry',
+    RegionalCoach = 'regionalCoach',
+    RegionalPassengerFerry = 'regionalPassengerFerry',
+    RegionalRail = 'regionalRail',
+    RegionalTram = 'regionalTram',
+    ReplacementRailService = 'replacementRailService',
+    RiverBus = 'riverBus',
+    RoadFerryLink = 'roadFerryLink',
+    RoundTripCharterFlight = 'roundTripCharterFlight',
+    ScheduledFerry = 'scheduledFerry',
+    SchoolAndPublicServiceBus = 'schoolAndPublicServiceBus',
+    SchoolBoat = 'schoolBoat',
+    SchoolBus = 'schoolBus',
+    SchoolCoach = 'schoolCoach',
+    ShortHaulInternationalFlight = 'shortHaulInternationalFlight',
+    ShuttleBus = 'shuttleBus',
+    ShuttleCoach = 'shuttleCoach',
+    ShuttleFerryService = 'shuttleFerryService',
+    ShuttleFlight = 'shuttleFlight',
+    ShuttleTram = 'shuttleTram',
+    SightseeingBus = 'sightseeingBus',
+    SightseeingCoach = 'sightseeingCoach',
+    SightseeingFlight = 'sightseeingFlight',
+    SightseeingService = 'sightseeingService',
+    SightseeingTram = 'sightseeingTram',
+    SleeperRailService = 'sleeperRailService',
+    SpecialCoach = 'specialCoach',
+    SpecialNeedsBus = 'specialNeedsBus',
+    SpecialTrain = 'specialTrain',
+    StreetCableCar = 'streetCableCar',
+    SuburbanRailway = 'suburbanRailway',
+    Telecabin = 'telecabin',
+    TelecabinLink = 'telecabinLink',
+    TouristCoach = 'touristCoach',
+    TouristRailway = 'touristRailway',
+    TrainFerry = 'trainFerry',
+    TrainTram = 'trainTram',
+    Tube = 'tube',
+    Undefined = 'undefined',
+    UndefinedFunicular = 'undefinedFunicular',
+    Unknown = 'unknown',
+    UrbanRailway = 'urbanRailway',
+    WaterTaxi = 'waterTaxi',
+}
+
+/** How much the factors safety, slope and distance are weighted relative to each other when routing bicycle legs. In total all three values need to add up to 1. */
+export type TriangleFactors = {
+    /** How important is bicycle safety expressed as a fraction of 1. */
+    safety: Scalars['Float']
+    /** How important is slope/elevation expressed as a fraction of 1. */
+    slope: Scalars['Float']
+    /** How important is time expressed as a fraction of 1. Note that what this really optimises for is distance (even if that means going over terrible surfaces, so I might be slower than the safe route). */
+    time: Scalars['Float']
+}
+
+/** Description of a travel between two places. */
+export type Trip = {
+    __typename?: 'Trip'
+    /** The time and date of travel */
+    dateTime: Maybe<Scalars['DateTime']>
+    /** Information about the timings for the trip generation */
+    debugOutput: DebugOutput
+    /** The origin */
+    fromPlace: Place
+    /**
+     * A list of possible error messages as enum
+     * @deprecated Use routingErrors instead
+     */
+    messageEnums: Array<Maybe<Scalars['String']>>
+    /**
+     * A list of possible error messages in cleartext
+     * @deprecated Use routingErrors instead
+     */
+    messageStrings: Array<Maybe<Scalars['String']>>
+    /** The trip request metadata. */
+    metadata: Maybe<TripSearchData>
+    /**
+     * Use the cursor to get the next page of results. Use this cursor for the pageCursor parameter in the trip query in order to get the next page.
+     * The next page is a set of itineraries departing AFTER the last itinerary in this result.
+     */
+    nextPageCursor: Maybe<Scalars['String']>
+    /**
+     * Use the cursor to get the previous page of results. Use this cursor for the pageCursor parameter in the trip query in order to get the previous page.
+     * The previous page is a set of itineraries departing BEFORE the first itinerary in this result.
+     */
+    previousPageCursor: Maybe<Scalars['String']>
+    /** A list of routing errors, and fields which caused them */
+    routingErrors: Array<RoutingError>
+    /** The destination */
+    toPlace: Place
+    /** A list of possible trip patterns */
+    tripPatterns: Array<TripPattern>
+}
+
+/** List of legs constituting a suggested sequence of rides and links for a specific trip. */
+export type TripPattern = {
+    __typename?: 'TripPattern'
+    /** The aimed date and time the trip ends. */
+    aimedEndTime: Scalars['DateTime']
+    /** The aimed date and time the trip starts. */
+    aimedStartTime: Scalars['DateTime']
+    /** NOT IMPLEMENTED. */
+    directDuration: Maybe<Scalars['Long']>
+    /** Total distance for the trip, in meters. NOT IMPLEMENTED */
+    distance: Maybe<Scalars['Float']>
+    /** Duration of the trip, in seconds. */
+    duration: Maybe<Scalars['Long']>
+    /**
+     * Time that the trip arrives.
+     * @deprecated Replaced with expectedEndTime
+     */
+    endTime: Maybe<Scalars['DateTime']>
+    /** The expected, realtime adjusted date and time the trip ends. */
+    expectedEndTime: Scalars['DateTime']
+    /** The expected, realtime adjusted date and time the trip starts. */
+    expectedStartTime: Scalars['DateTime']
+    /** Generalized cost or weight of the itinerary. Used for debugging. */
+    generalizedCost: Maybe<Scalars['Int']>
+    /** A list of legs. Each leg is either a walking (cycling, car) portion of the trip, or a ride leg on a particular vehicle. So a trip where the use walks to the Q train, transfers to the 6, then walks to their destination, has four legs. */
+    legs: Array<Leg>
+    /**
+     * Time that the trip departs.
+     * @deprecated Replaced with expectedStartTime
+     */
+    startTime: Maybe<Scalars['DateTime']>
+    /** Get all system notices. */
+    systemNotices: Array<SystemNotice>
+    /** A cost calculated to favor transfer with higher priority. This field is meant for debugging only. */
+    transferPriorityCost: Maybe<Scalars['Int']>
+    /** A cost calculated to distribute wait-time and avoid very short transfers. This field is meant for debugging only. */
+    waitTimeOptimizedCost: Maybe<Scalars['Int']>
+    /** How much time is spent waiting for transit to arrive, in seconds. */
+    waitingTime: Maybe<Scalars['Long']>
+    /** How far the user has to walk, in meters. */
+    walkDistance: Maybe<Scalars['Float']>
+    /** How much time is spent walking, in seconds. */
+    walkTime: Maybe<Scalars['Long']>
+}
+
+/** Trips search metadata. */
+export type TripSearchData = {
+    __typename?: 'TripSearchData'
+    /**
+     * This is the suggested search time for the "next page" or time window. Insert it together with the 'searchWindowUsed' in the request to get a new set of trips following in the time-window AFTER the current search.
+     * @deprecated Use pageCursor instead
+     */
+    nextDateTime: Maybe<Scalars['DateTime']>
+    /**
+     * This is the suggested search time for the "previous page" or time-window. Insert it together with the 'searchWindowUsed' in the request to get a new set of trips preceding in the time-window BEFORE the current search.
+     * @deprecated Use pageCursor instead
+     */
+    prevDateTime: Maybe<Scalars['DateTime']>
+    /** This is the time window used by the raptor search. The input searchWindow is an optional parameter and is dynamically assigned if not set. OTP might override the value if it is too small or too large. When paging OTP adjusts it to the appropriate size, depending on the number of itineraries found in the current search window. The scaling of the search window ensures faster paging and limits resource usage. The unit is seconds. */
+    searchWindowUsed: Scalars['Int']
+}
+
+export type ValidityPeriod = {
+    __typename?: 'ValidityPeriod'
+    /** End of validity period. Will return 'null' if validity is open-ended. */
+    endTime: Maybe<Scalars['DateTime']>
+    /** Start of validity period */
+    startTime: Maybe<Scalars['DateTime']>
+}
+
+export enum VertexType {
+    BikePark = 'bikePark',
+    BikeShare = 'bikeShare',
+    Normal = 'normal',
+    Transit = 'transit',
+}
+
+export enum WheelchairBoarding {
+    /** There is no accessibility information for the stopPlace/quay. */
+    NoInformation = 'noInformation',
+    /** Wheelchair boarding/alighting is not possible at this stop. */
+    NotPossible = 'notPossible',
+    /** Boarding wheelchair-accessible serviceJourneys is possible at this stopPlace/quay. */
+    Possible = 'possible',
+}
+
+export type DebugOutput = {
+    __typename?: 'debugOutput'
+    totalTime: Maybe<Scalars['Long']>
+}
+
+export type InfoLink = {
+    __typename?: 'infoLink'
+    /** Label */
+    label: Maybe<Scalars['String']>
+    /** URI */
+    uri: Maybe<Scalars['String']>
+}
+
+/** A connection to a list of items. */
+export type PlaceAtDistanceConnection = {
+    __typename?: 'placeAtDistanceConnection'
+    /** a list of edges */
+    edges: Maybe<Array<Maybe<PlaceAtDistanceEdge>>>
+    /** details about this specific page */
+    pageInfo: PageInfo
+}
+
+/** An edge in a connection */
+export type PlaceAtDistanceEdge = {
+    __typename?: 'placeAtDistanceEdge'
+    /** cursor marks a unique position or index into the connection */
+    cursor: Scalars['String']
+    /** The item at the end of the edge */
+    node: Maybe<PlaceAtDistance>
+}
+
+/** A connection to a list of items. */
+export type QuayAtDistanceConnection = {
+    __typename?: 'quayAtDistanceConnection'
+    /** a list of edges */
+    edges: Maybe<Array<Maybe<QuayAtDistanceEdge>>>
+    /** details about this specific page */
+    pageInfo: PageInfo
+}
+
+/** An edge in a connection */
+export type QuayAtDistanceEdge = {
+    __typename?: 'quayAtDistanceEdge'
+    /** cursor marks a unique position or index into the connection */
+    cursor: Scalars['String']
+    /** The item at the end of the edge */
+    node: Maybe<QuayAtDistance>
+}
+
+export type GetTripPatternsQueryVariables = Exact<{
+    numTripPatterns?: InputMaybe<Scalars['Int']>
+    from: Location
+    to: Location
+    dateTime: Scalars['DateTime']
+    arriveBy: Scalars['Boolean']
+    wheelchairAccessible: Scalars['Boolean']
+    modes: Modes
+    walkSpeed?: InputMaybe<Scalars['Float']>
+    minimumTransferTime?: InputMaybe<Scalars['Int']>
+    banned?: InputMaybe<InputBanned>
+    whiteListed?: InputMaybe<InputWhiteListed>
+    debugItineraryFilter?: InputMaybe<Scalars['Boolean']>
+    searchWindow?: InputMaybe<Scalars['Int']>
+}>
+
+export type GetTripPatternsQuery = {
+    __typename?: 'QueryType'
+    trip: {
+        __typename?: 'Trip'
+        metadata:
+            | {
+                  __typename?: 'TripSearchData'
+                  searchWindowUsed: number
+                  nextDateTime: string | null | undefined
+                  prevDateTime: string | null | undefined
+              }
+            | null
+            | undefined
+        routingErrors: Array<{
+            __typename?: 'RoutingError'
+            inputField: InputField | null | undefined
+            description: string
+            code: RoutingErrorCode
+        }>
+        tripPatterns: Array<{
+            __typename?: 'TripPattern'
+            generalizedCost: number | null | undefined
+            startTime: string | null | undefined
+            endTime: string | null | undefined
+            expectedStartTime: string
+            expectedEndTime: string
+            directDuration: number | null | undefined
+            duration: number | null | undefined
+            distance: number | null | undefined
+            walkDistance: number | null | undefined
+            systemNotices: Array<{
+                __typename?: 'SystemNotice'
+                tag: string | null | undefined
+                text: string | null | undefined
+            }>
+            legs: Array<{
+                __typename?: 'Leg'
+                generalizedCost: number | null | undefined
+                aimedEndTime: string
+                aimedStartTime: string
+                distance: number | null | undefined
+                directDuration: number | null | undefined
+                duration: number | null | undefined
+                expectedEndTime: string
+                expectedStartTime: string
+                mode: Mode
+                realtime: boolean
+                ride: boolean
+                rentedBike: boolean | null | undefined
+                transportSubmode: TransportSubmode | null | undefined
+                authority:
+                    | {
+                          __typename?: 'Authority'
+                          id: string
+                          name: string
+                          url: string | null | undefined
+                      }
+                    | null
+                    | undefined
+                fromEstimatedCall:
+                    | {
+                          __typename?: 'EstimatedCall'
+                          actualArrivalTime: string | null | undefined
+                          actualDepartureTime: string | null | undefined
+                          aimedArrivalTime: string
+                          aimedDepartureTime: string
+                          cancellation: boolean
+                          date: string | null | undefined
+                          expectedDepartureTime: string
+                          expectedArrivalTime: string
+                          forAlighting: boolean
+                          forBoarding: boolean
+                          predictionInaccurate: boolean
+                          realtime: boolean
+                          requestStop: boolean
+                          destinationDisplay:
+                              | {
+                                    __typename?: 'DestinationDisplay'
+                                    frontText: string | null | undefined
+                                }
+                              | null
+                              | undefined
+                          notices: Array<{
+                              __typename?: 'Notice'
+                              text: string | null | undefined
+                          }>
+                          quay:
+                              | {
+                                    __typename?: 'Quay'
+                                    id: string
+                                    name: string
+                                    description: string | null | undefined
+                                    publicCode: string | null | undefined
+                                    situations: Array<
+                                        | {
+                                              __typename?: 'PtSituationElement'
+                                              situationNumber:
+                                                  | string
+                                                  | null
+                                                  | undefined
+                                              reportType:
+                                                  | ReportType
+                                                  | null
+                                                  | undefined
+                                              summary: Array<{
+                                                  __typename?: 'MultilingualString'
+                                                  language:
+                                                      | string
+                                                      | null
+                                                      | undefined
+                                                  value:
+                                                      | string
+                                                      | null
+                                                      | undefined
+                                              }>
+                                              description: Array<{
+                                                  __typename?: 'MultilingualString'
+                                                  language:
+                                                      | string
+                                                      | null
+                                                      | undefined
+                                                  value:
+                                                      | string
+                                                      | null
+                                                      | undefined
+                                              }>
+                                              advice: Array<{
+                                                  __typename?: 'MultilingualString'
+                                                  language:
+                                                      | string
+                                                      | null
+                                                      | undefined
+                                                  value:
+                                                      | string
+                                                      | null
+                                                      | undefined
+                                              }>
+                                              validityPeriod:
+                                                  | {
+                                                        __typename?: 'ValidityPeriod'
+                                                        startTime:
+                                                            | string
+                                                            | null
+                                                            | undefined
+                                                        endTime:
+                                                            | string
+                                                            | null
+                                                            | undefined
+                                                    }
+                                                  | null
+                                                  | undefined
+                                              infoLinks:
+                                                  | Array<
+                                                        | {
+                                                              __typename?: 'infoLink'
+                                                              uri:
+                                                                  | string
+                                                                  | null
+                                                                  | undefined
+                                                              label:
+                                                                  | string
+                                                                  | null
+                                                                  | undefined
+                                                          }
+                                                        | null
+                                                        | undefined
+                                                    >
+                                                  | null
+                                                  | undefined
+                                          }
+                                        | null
+                                        | undefined
+                                    >
+                                    stopPlace:
+                                        | {
+                                              __typename?: 'StopPlace'
+                                              id: string
+                                              description:
+                                                  | string
+                                                  | null
+                                                  | undefined
+                                              name: string
+                                              latitude:
+                                                  | number
+                                                  | null
+                                                  | undefined
+                                              longitude:
+                                                  | number
+                                                  | null
+                                                  | undefined
+                                              tariffZones: Array<
+                                                  | {
+                                                        __typename?: 'TariffZone'
+                                                        id: string
+                                                    }
+                                                  | null
+                                                  | undefined
+                                              >
+                                          }
+                                        | null
+                                        | undefined
+                                }
+                              | null
+                              | undefined
+                          serviceJourney:
+                              | {
+                                    __typename?: 'ServiceJourney'
+                                    id: string
+                                    publicCode: string | null | undefined
+                                    privateCode: string | null | undefined
+                                    journeyPattern:
+                                        | {
+                                              __typename?: 'JourneyPattern'
+                                              line: {
+                                                  __typename?: 'Line'
+                                                  description:
+                                                      | string
+                                                      | null
+                                                      | undefined
+                                                  flexibleLineType:
+                                                      | string
+                                                      | null
+                                                      | undefined
+                                                  id: string
+                                                  name:
+                                                      | string
+                                                      | null
+                                                      | undefined
+                                                  publicCode:
+                                                      | string
+                                                      | null
+                                                      | undefined
+                                                  transportMode:
+                                                      | TransportMode
+                                                      | null
+                                                      | undefined
+                                                  transportSubmode:
+                                                      | TransportSubmode
+                                                      | null
+                                                      | undefined
+                                                  notices: Array<
+                                                      | {
+                                                            __typename?: 'Notice'
+                                                            text:
+                                                                | string
+                                                                | null
+                                                                | undefined
+                                                        }
+                                                      | null
+                                                      | undefined
+                                                  >
+                                              }
+                                              notices: Array<
+                                                  | {
+                                                        __typename?: 'Notice'
+                                                        text:
+                                                            | string
+                                                            | null
+                                                            | undefined
+                                                    }
+                                                  | null
+                                                  | undefined
+                                              >
+                                          }
+                                        | null
+                                        | undefined
+                                    notices: Array<
+                                        | {
+                                              __typename?: 'Notice'
+                                              text: string | null | undefined
+                                          }
+                                        | null
+                                        | undefined
+                                    >
+                                }
+                              | null
+                              | undefined
+                      }
+                    | null
+                    | undefined
+                fromPlace: {
+                    __typename?: 'Place'
+                    name: string | null | undefined
+                    latitude: number
+                    longitude: number
+                    quay:
+                        | {
+                              __typename?: 'Quay'
+                              id: string
+                              name: string
+                              description: string | null | undefined
+                              publicCode: string | null | undefined
+                              situations: Array<
+                                  | {
+                                        __typename?: 'PtSituationElement'
+                                        situationNumber:
+                                            | string
+                                            | null
+                                            | undefined
+                                        reportType:
+                                            | ReportType
+                                            | null
+                                            | undefined
+                                        summary: Array<{
+                                            __typename?: 'MultilingualString'
+                                            language: string | null | undefined
+                                            value: string | null | undefined
+                                        }>
+                                        description: Array<{
+                                            __typename?: 'MultilingualString'
+                                            language: string | null | undefined
+                                            value: string | null | undefined
+                                        }>
+                                        advice: Array<{
+                                            __typename?: 'MultilingualString'
+                                            language: string | null | undefined
+                                            value: string | null | undefined
+                                        }>
+                                        validityPeriod:
+                                            | {
+                                                  __typename?: 'ValidityPeriod'
+                                                  startTime:
+                                                      | string
+                                                      | null
+                                                      | undefined
+                                                  endTime:
+                                                      | string
+                                                      | null
+                                                      | undefined
+                                              }
+                                            | null
+                                            | undefined
+                                        infoLinks:
+                                            | Array<
+                                                  | {
+                                                        __typename?: 'infoLink'
+                                                        uri:
+                                                            | string
+                                                            | null
+                                                            | undefined
+                                                        label:
+                                                            | string
+                                                            | null
+                                                            | undefined
+                                                    }
+                                                  | null
+                                                  | undefined
+                                              >
+                                            | null
+                                            | undefined
+                                    }
+                                  | null
+                                  | undefined
+                              >
+                              stopPlace:
+                                  | {
+                                        __typename?: 'StopPlace'
+                                        id: string
+                                        description: string | null | undefined
+                                        name: string
+                                        latitude: number | null | undefined
+                                        longitude: number | null | undefined
+                                        tariffZones: Array<
+                                            | {
+                                                  __typename?: 'TariffZone'
+                                                  id: string
+                                              }
+                                            | null
+                                            | undefined
+                                        >
+                                    }
+                                  | null
+                                  | undefined
+                          }
+                        | null
+                        | undefined
+                    bikeRentalStation:
+                        | {
+                              __typename?: 'BikeRentalStation'
+                              id: string
+                              name: string
+                              networks: Array<string | null | undefined>
+                              bikesAvailable: number | null | undefined
+                              spacesAvailable: number | null | undefined
+                              longitude: number | null | undefined
+                              latitude: number | null | undefined
+                          }
+                        | null
+                        | undefined
+                }
+                interchangeFrom:
+                    | {
+                          __typename?: 'Interchange'
+                          guaranteed: boolean | null | undefined
+                          staySeated: boolean | null | undefined
+                          maximumWaitTime: number | null | undefined
+                          fromServiceJourney:
+                              | { __typename?: 'ServiceJourney'; id: string }
+                              | null
+                              | undefined
+                          toServiceJourney:
+                              | { __typename?: 'ServiceJourney'; id: string }
+                              | null
+                              | undefined
+                      }
+                    | null
+                    | undefined
+                interchangeTo:
+                    | {
+                          __typename?: 'Interchange'
+                          guaranteed: boolean | null | undefined
+                          staySeated: boolean | null | undefined
+                          maximumWaitTime: number | null | undefined
+                          fromServiceJourney:
+                              | { __typename?: 'ServiceJourney'; id: string }
+                              | null
+                              | undefined
+                          toServiceJourney:
+                              | { __typename?: 'ServiceJourney'; id: string }
+                              | null
+                              | undefined
+                      }
+                    | null
+                    | undefined
+                intermediateEstimatedCalls: Array<{
+                    __typename?: 'EstimatedCall'
+                    actualArrivalTime: string | null | undefined
+                    actualDepartureTime: string | null | undefined
+                    aimedArrivalTime: string
+                    aimedDepartureTime: string
+                    cancellation: boolean
+                    date: string | null | undefined
+                    expectedDepartureTime: string
+                    expectedArrivalTime: string
+                    forAlighting: boolean
+                    forBoarding: boolean
+                    predictionInaccurate: boolean
+                    realtime: boolean
+                    requestStop: boolean
+                    destinationDisplay:
+                        | {
+                              __typename?: 'DestinationDisplay'
+                              frontText: string | null | undefined
+                          }
+                        | null
+                        | undefined
+                    notices: Array<{
+                        __typename?: 'Notice'
+                        text: string | null | undefined
+                    }>
+                    quay:
+                        | {
+                              __typename?: 'Quay'
+                              id: string
+                              name: string
+                              description: string | null | undefined
+                              publicCode: string | null | undefined
+                              situations: Array<
+                                  | {
+                                        __typename?: 'PtSituationElement'
+                                        situationNumber:
+                                            | string
+                                            | null
+                                            | undefined
+                                        reportType:
+                                            | ReportType
+                                            | null
+                                            | undefined
+                                        summary: Array<{
+                                            __typename?: 'MultilingualString'
+                                            language: string | null | undefined
+                                            value: string | null | undefined
+                                        }>
+                                        description: Array<{
+                                            __typename?: 'MultilingualString'
+                                            language: string | null | undefined
+                                            value: string | null | undefined
+                                        }>
+                                        advice: Array<{
+                                            __typename?: 'MultilingualString'
+                                            language: string | null | undefined
+                                            value: string | null | undefined
+                                        }>
+                                        validityPeriod:
+                                            | {
+                                                  __typename?: 'ValidityPeriod'
+                                                  startTime:
+                                                      | string
+                                                      | null
+                                                      | undefined
+                                                  endTime:
+                                                      | string
+                                                      | null
+                                                      | undefined
+                                              }
+                                            | null
+                                            | undefined
+                                        infoLinks:
+                                            | Array<
+                                                  | {
+                                                        __typename?: 'infoLink'
+                                                        uri:
+                                                            | string
+                                                            | null
+                                                            | undefined
+                                                        label:
+                                                            | string
+                                                            | null
+                                                            | undefined
+                                                    }
+                                                  | null
+                                                  | undefined
+                                              >
+                                            | null
+                                            | undefined
+                                    }
+                                  | null
+                                  | undefined
+                              >
+                              stopPlace:
+                                  | {
+                                        __typename?: 'StopPlace'
+                                        id: string
+                                        description: string | null | undefined
+                                        name: string
+                                        latitude: number | null | undefined
+                                        longitude: number | null | undefined
+                                        tariffZones: Array<
+                                            | {
+                                                  __typename?: 'TariffZone'
+                                                  id: string
+                                              }
+                                            | null
+                                            | undefined
+                                        >
+                                    }
+                                  | null
+                                  | undefined
+                          }
+                        | null
+                        | undefined
+                    serviceJourney:
+                        | {
+                              __typename?: 'ServiceJourney'
+                              id: string
+                              publicCode: string | null | undefined
+                              privateCode: string | null | undefined
+                              journeyPattern:
+                                  | {
+                                        __typename?: 'JourneyPattern'
+                                        line: {
+                                            __typename?: 'Line'
+                                            description:
+                                                | string
+                                                | null
+                                                | undefined
+                                            flexibleLineType:
+                                                | string
+                                                | null
+                                                | undefined
+                                            id: string
+                                            name: string | null | undefined
+                                            publicCode:
+                                                | string
+                                                | null
+                                                | undefined
+                                            transportMode:
+                                                | TransportMode
+                                                | null
+                                                | undefined
+                                            transportSubmode:
+                                                | TransportSubmode
+                                                | null
+                                                | undefined
+                                            notices: Array<
+                                                | {
+                                                      __typename?: 'Notice'
+                                                      text:
+                                                          | string
+                                                          | null
+                                                          | undefined
+                                                  }
+                                                | null
+                                                | undefined
+                                            >
+                                        }
+                                        notices: Array<
+                                            | {
+                                                  __typename?: 'Notice'
+                                                  text:
+                                                      | string
+                                                      | null
+                                                      | undefined
+                                              }
+                                            | null
+                                            | undefined
+                                        >
+                                    }
+                                  | null
+                                  | undefined
+                              notices: Array<
+                                  | {
+                                        __typename?: 'Notice'
+                                        text: string | null | undefined
+                                    }
+                                  | null
+                                  | undefined
+                              >
+                          }
+                        | null
+                        | undefined
+                }>
+                line:
+                    | {
+                          __typename?: 'Line'
+                          description: string | null | undefined
+                          flexibleLineType: string | null | undefined
+                          id: string
+                          name: string | null | undefined
+                          publicCode: string | null | undefined
+                          transportMode: TransportMode | null | undefined
+                          transportSubmode: TransportSubmode | null | undefined
+                          notices: Array<
+                              | {
+                                    __typename?: 'Notice'
+                                    text: string | null | undefined
+                                }
+                              | null
+                              | undefined
+                          >
+                      }
+                    | null
+                    | undefined
+                operator:
+                    | {
+                          __typename?: 'Operator'
+                          id: string
+                          name: string
+                          url: string | null | undefined
+                      }
+                    | null
+                    | undefined
+                pointsOnLink:
+                    | {
+                          __typename?: 'PointsOnLink'
+                          points: string | null | undefined
+                          length: number | null | undefined
+                      }
+                    | null
+                    | undefined
+                serviceJourney:
+                    | {
+                          __typename?: 'ServiceJourney'
+                          id: string
+                          publicCode: string | null | undefined
+                          privateCode: string | null | undefined
+                          journeyPattern:
+                              | {
+                                    __typename?: 'JourneyPattern'
+                                    line: {
+                                        __typename?: 'Line'
+                                        description: string | null | undefined
+                                        flexibleLineType:
+                                            | string
+                                            | null
+                                            | undefined
+                                        id: string
+                                        name: string | null | undefined
+                                        publicCode: string | null | undefined
+                                        transportMode:
+                                            | TransportMode
+                                            | null
+                                            | undefined
+                                        transportSubmode:
+                                            | TransportSubmode
+                                            | null
+                                            | undefined
+                                        notices: Array<
+                                            | {
+                                                  __typename?: 'Notice'
+                                                  text:
+                                                      | string
+                                                      | null
+                                                      | undefined
+                                              }
+                                            | null
+                                            | undefined
+                                        >
+                                    }
+                                    notices: Array<
+                                        | {
+                                              __typename?: 'Notice'
+                                              text: string | null | undefined
+                                          }
+                                        | null
+                                        | undefined
+                                    >
+                                }
+                              | null
+                              | undefined
+                          notices: Array<
+                              | {
+                                    __typename?: 'Notice'
+                                    text: string | null | undefined
+                                }
+                              | null
+                              | undefined
+                          >
+                      }
+                    | null
+                    | undefined
+                situations: Array<{
+                    __typename?: 'PtSituationElement'
+                    situationNumber: string | null | undefined
+                    reportType: ReportType | null | undefined
+                    summary: Array<{
+                        __typename?: 'MultilingualString'
+                        language: string | null | undefined
+                        value: string | null | undefined
+                    }>
+                    description: Array<{
+                        __typename?: 'MultilingualString'
+                        language: string | null | undefined
+                        value: string | null | undefined
+                    }>
+                    advice: Array<{
+                        __typename?: 'MultilingualString'
+                        language: string | null | undefined
+                        value: string | null | undefined
+                    }>
+                    validityPeriod:
+                        | {
+                              __typename?: 'ValidityPeriod'
+                              startTime: string | null | undefined
+                              endTime: string | null | undefined
+                          }
+                        | null
+                        | undefined
+                    infoLinks:
+                        | Array<
+                              | {
+                                    __typename?: 'infoLink'
+                                    uri: string | null | undefined
+                                    label: string | null | undefined
+                                }
+                              | null
+                              | undefined
+                          >
+                        | null
+                        | undefined
+                }>
+                toEstimatedCall:
+                    | {
+                          __typename?: 'EstimatedCall'
+                          actualArrivalTime: string | null | undefined
+                          actualDepartureTime: string | null | undefined
+                          aimedArrivalTime: string
+                          aimedDepartureTime: string
+                          cancellation: boolean
+                          date: string | null | undefined
+                          expectedDepartureTime: string
+                          expectedArrivalTime: string
+                          forAlighting: boolean
+                          forBoarding: boolean
+                          predictionInaccurate: boolean
+                          realtime: boolean
+                          requestStop: boolean
+                          destinationDisplay:
+                              | {
+                                    __typename?: 'DestinationDisplay'
+                                    frontText: string | null | undefined
+                                }
+                              | null
+                              | undefined
+                          notices: Array<{
+                              __typename?: 'Notice'
+                              text: string | null | undefined
+                          }>
+                          quay:
+                              | {
+                                    __typename?: 'Quay'
+                                    id: string
+                                    name: string
+                                    description: string | null | undefined
+                                    publicCode: string | null | undefined
+                                    situations: Array<
+                                        | {
+                                              __typename?: 'PtSituationElement'
+                                              situationNumber:
+                                                  | string
+                                                  | null
+                                                  | undefined
+                                              reportType:
+                                                  | ReportType
+                                                  | null
+                                                  | undefined
+                                              summary: Array<{
+                                                  __typename?: 'MultilingualString'
+                                                  language:
+                                                      | string
+                                                      | null
+                                                      | undefined
+                                                  value:
+                                                      | string
+                                                      | null
+                                                      | undefined
+                                              }>
+                                              description: Array<{
+                                                  __typename?: 'MultilingualString'
+                                                  language:
+                                                      | string
+                                                      | null
+                                                      | undefined
+                                                  value:
+                                                      | string
+                                                      | null
+                                                      | undefined
+                                              }>
+                                              advice: Array<{
+                                                  __typename?: 'MultilingualString'
+                                                  language:
+                                                      | string
+                                                      | null
+                                                      | undefined
+                                                  value:
+                                                      | string
+                                                      | null
+                                                      | undefined
+                                              }>
+                                              validityPeriod:
+                                                  | {
+                                                        __typename?: 'ValidityPeriod'
+                                                        startTime:
+                                                            | string
+                                                            | null
+                                                            | undefined
+                                                        endTime:
+                                                            | string
+                                                            | null
+                                                            | undefined
+                                                    }
+                                                  | null
+                                                  | undefined
+                                              infoLinks:
+                                                  | Array<
+                                                        | {
+                                                              __typename?: 'infoLink'
+                                                              uri:
+                                                                  | string
+                                                                  | null
+                                                                  | undefined
+                                                              label:
+                                                                  | string
+                                                                  | null
+                                                                  | undefined
+                                                          }
+                                                        | null
+                                                        | undefined
+                                                    >
+                                                  | null
+                                                  | undefined
+                                          }
+                                        | null
+                                        | undefined
+                                    >
+                                    stopPlace:
+                                        | {
+                                              __typename?: 'StopPlace'
+                                              id: string
+                                              description:
+                                                  | string
+                                                  | null
+                                                  | undefined
+                                              name: string
+                                              latitude:
+                                                  | number
+                                                  | null
+                                                  | undefined
+                                              longitude:
+                                                  | number
+                                                  | null
+                                                  | undefined
+                                              tariffZones: Array<
+                                                  | {
+                                                        __typename?: 'TariffZone'
+                                                        id: string
+                                                    }
+                                                  | null
+                                                  | undefined
+                                              >
+                                          }
+                                        | null
+                                        | undefined
+                                }
+                              | null
+                              | undefined
+                          serviceJourney:
+                              | {
+                                    __typename?: 'ServiceJourney'
+                                    id: string
+                                    publicCode: string | null | undefined
+                                    privateCode: string | null | undefined
+                                    journeyPattern:
+                                        | {
+                                              __typename?: 'JourneyPattern'
+                                              line: {
+                                                  __typename?: 'Line'
+                                                  description:
+                                                      | string
+                                                      | null
+                                                      | undefined
+                                                  flexibleLineType:
+                                                      | string
+                                                      | null
+                                                      | undefined
+                                                  id: string
+                                                  name:
+                                                      | string
+                                                      | null
+                                                      | undefined
+                                                  publicCode:
+                                                      | string
+                                                      | null
+                                                      | undefined
+                                                  transportMode:
+                                                      | TransportMode
+                                                      | null
+                                                      | undefined
+                                                  transportSubmode:
+                                                      | TransportSubmode
+                                                      | null
+                                                      | undefined
+                                                  notices: Array<
+                                                      | {
+                                                            __typename?: 'Notice'
+                                                            text:
+                                                                | string
+                                                                | null
+                                                                | undefined
+                                                        }
+                                                      | null
+                                                      | undefined
+                                                  >
+                                              }
+                                              notices: Array<
+                                                  | {
+                                                        __typename?: 'Notice'
+                                                        text:
+                                                            | string
+                                                            | null
+                                                            | undefined
+                                                    }
+                                                  | null
+                                                  | undefined
+                                              >
+                                          }
+                                        | null
+                                        | undefined
+                                    notices: Array<
+                                        | {
+                                              __typename?: 'Notice'
+                                              text: string | null | undefined
+                                          }
+                                        | null
+                                        | undefined
+                                    >
+                                }
+                              | null
+                              | undefined
+                      }
+                    | null
+                    | undefined
+                toPlace: {
+                    __typename?: 'Place'
+                    name: string | null | undefined
+                    latitude: number
+                    longitude: number
+                    quay:
+                        | {
+                              __typename?: 'Quay'
+                              id: string
+                              name: string
+                              description: string | null | undefined
+                              publicCode: string | null | undefined
+                              situations: Array<
+                                  | {
+                                        __typename?: 'PtSituationElement'
+                                        situationNumber:
+                                            | string
+                                            | null
+                                            | undefined
+                                        reportType:
+                                            | ReportType
+                                            | null
+                                            | undefined
+                                        summary: Array<{
+                                            __typename?: 'MultilingualString'
+                                            language: string | null | undefined
+                                            value: string | null | undefined
+                                        }>
+                                        description: Array<{
+                                            __typename?: 'MultilingualString'
+                                            language: string | null | undefined
+                                            value: string | null | undefined
+                                        }>
+                                        advice: Array<{
+                                            __typename?: 'MultilingualString'
+                                            language: string | null | undefined
+                                            value: string | null | undefined
+                                        }>
+                                        validityPeriod:
+                                            | {
+                                                  __typename?: 'ValidityPeriod'
+                                                  startTime:
+                                                      | string
+                                                      | null
+                                                      | undefined
+                                                  endTime:
+                                                      | string
+                                                      | null
+                                                      | undefined
+                                              }
+                                            | null
+                                            | undefined
+                                        infoLinks:
+                                            | Array<
+                                                  | {
+                                                        __typename?: 'infoLink'
+                                                        uri:
+                                                            | string
+                                                            | null
+                                                            | undefined
+                                                        label:
+                                                            | string
+                                                            | null
+                                                            | undefined
+                                                    }
+                                                  | null
+                                                  | undefined
+                                              >
+                                            | null
+                                            | undefined
+                                    }
+                                  | null
+                                  | undefined
+                              >
+                              stopPlace:
+                                  | {
+                                        __typename?: 'StopPlace'
+                                        id: string
+                                        description: string | null | undefined
+                                        name: string
+                                        latitude: number | null | undefined
+                                        longitude: number | null | undefined
+                                        tariffZones: Array<
+                                            | {
+                                                  __typename?: 'TariffZone'
+                                                  id: string
+                                              }
+                                            | null
+                                            | undefined
+                                        >
+                                    }
+                                  | null
+                                  | undefined
+                          }
+                        | null
+                        | undefined
+                    bikeRentalStation:
+                        | {
+                              __typename?: 'BikeRentalStation'
+                              id: string
+                              name: string
+                              networks: Array<string | null | undefined>
+                              bikesAvailable: number | null | undefined
+                              spacesAvailable: number | null | undefined
+                              longitude: number | null | undefined
+                              latitude: number | null | undefined
+                          }
+                        | null
+                        | undefined
+                }
+                bookingArrangements:
+                    | {
+                          __typename?: 'BookingArrangement'
+                          bookingMethods:
+                              | Array<BookingMethod | null | undefined>
+                              | null
+                              | undefined
+                          bookingNote: string | null | undefined
+                          latestBookingTime: string | null | undefined
+                          minimumBookingPeriod: string | null | undefined
+                          bookWhen: PurchaseWhen | null | undefined
+                          bookingContact:
+                              | {
+                                    __typename?: 'Contact'
+                                    phone: string | null | undefined
+                                    url: string | null | undefined
+                                }
+                              | null
+                              | undefined
+                      }
+                    | null
+                    | undefined
+            }>
+        }>
+    }
+}
+
+export type LegFieldsFragment = {
+    __typename?: 'Leg'
+    aimedEndTime: string
+    aimedStartTime: string
+    distance: number | null | undefined
+    directDuration: number | null | undefined
+    duration: number | null | undefined
+    expectedEndTime: string
+    expectedStartTime: string
+    mode: Mode
+    realtime: boolean
+    ride: boolean
+    rentedBike: boolean | null | undefined
+    transportSubmode: TransportSubmode | null | undefined
+    authority:
+        | {
+              __typename?: 'Authority'
+              id: string
+              name: string
+              url: string | null | undefined
+          }
+        | null
+        | undefined
+    fromEstimatedCall:
+        | {
+              __typename?: 'EstimatedCall'
+              actualArrivalTime: string | null | undefined
+              actualDepartureTime: string | null | undefined
+              aimedArrivalTime: string
+              aimedDepartureTime: string
+              cancellation: boolean
+              date: string | null | undefined
+              expectedDepartureTime: string
+              expectedArrivalTime: string
+              forAlighting: boolean
+              forBoarding: boolean
+              predictionInaccurate: boolean
+              realtime: boolean
+              requestStop: boolean
+              destinationDisplay:
+                  | {
+                        __typename?: 'DestinationDisplay'
+                        frontText: string | null | undefined
+                    }
+                  | null
+                  | undefined
+              notices: Array<{
+                  __typename?: 'Notice'
+                  text: string | null | undefined
+              }>
+              quay:
+                  | {
+                        __typename?: 'Quay'
+                        id: string
+                        name: string
+                        description: string | null | undefined
+                        publicCode: string | null | undefined
+                        situations: Array<
+                            | {
+                                  __typename?: 'PtSituationElement'
+                                  situationNumber: string | null | undefined
+                                  reportType: ReportType | null | undefined
+                                  summary: Array<{
+                                      __typename?: 'MultilingualString'
+                                      language: string | null | undefined
+                                      value: string | null | undefined
+                                  }>
+                                  description: Array<{
+                                      __typename?: 'MultilingualString'
+                                      language: string | null | undefined
+                                      value: string | null | undefined
+                                  }>
+                                  advice: Array<{
+                                      __typename?: 'MultilingualString'
+                                      language: string | null | undefined
+                                      value: string | null | undefined
+                                  }>
+                                  validityPeriod:
+                                      | {
+                                            __typename?: 'ValidityPeriod'
+                                            startTime: string | null | undefined
+                                            endTime: string | null | undefined
+                                        }
+                                      | null
+                                      | undefined
+                                  infoLinks:
+                                      | Array<
+                                            | {
+                                                  __typename?: 'infoLink'
+                                                  uri: string | null | undefined
+                                                  label:
+                                                      | string
+                                                      | null
+                                                      | undefined
+                                              }
+                                            | null
+                                            | undefined
+                                        >
+                                      | null
+                                      | undefined
+                              }
+                            | null
+                            | undefined
+                        >
+                        stopPlace:
+                            | {
+                                  __typename?: 'StopPlace'
+                                  id: string
+                                  description: string | null | undefined
+                                  name: string
+                                  latitude: number | null | undefined
+                                  longitude: number | null | undefined
+                                  tariffZones: Array<
+                                      | {
+                                            __typename?: 'TariffZone'
+                                            id: string
+                                        }
+                                      | null
+                                      | undefined
+                                  >
+                              }
+                            | null
+                            | undefined
+                    }
+                  | null
+                  | undefined
+              serviceJourney:
+                  | {
+                        __typename?: 'ServiceJourney'
+                        id: string
+                        publicCode: string | null | undefined
+                        privateCode: string | null | undefined
+                        journeyPattern:
+                            | {
+                                  __typename?: 'JourneyPattern'
+                                  line: {
+                                      __typename?: 'Line'
+                                      description: string | null | undefined
+                                      flexibleLineType:
+                                          | string
+                                          | null
+                                          | undefined
+                                      id: string
+                                      name: string | null | undefined
+                                      publicCode: string | null | undefined
+                                      transportMode:
+                                          | TransportMode
+                                          | null
+                                          | undefined
+                                      transportSubmode:
+                                          | TransportSubmode
+                                          | null
+                                          | undefined
+                                      notices: Array<
+                                          | {
+                                                __typename?: 'Notice'
+                                                text: string | null | undefined
+                                            }
+                                          | null
+                                          | undefined
+                                      >
+                                  }
+                                  notices: Array<
+                                      | {
+                                            __typename?: 'Notice'
+                                            text: string | null | undefined
+                                        }
+                                      | null
+                                      | undefined
+                                  >
+                              }
+                            | null
+                            | undefined
+                        notices: Array<
+                            | {
+                                  __typename?: 'Notice'
+                                  text: string | null | undefined
+                              }
+                            | null
+                            | undefined
+                        >
+                    }
+                  | null
+                  | undefined
+          }
+        | null
+        | undefined
+    fromPlace: {
+        __typename?: 'Place'
+        name: string | null | undefined
+        latitude: number
+        longitude: number
+        quay:
+            | {
+                  __typename?: 'Quay'
+                  id: string
+                  name: string
+                  description: string | null | undefined
+                  publicCode: string | null | undefined
+                  situations: Array<
+                      | {
+                            __typename?: 'PtSituationElement'
+                            situationNumber: string | null | undefined
+                            reportType: ReportType | null | undefined
+                            summary: Array<{
+                                __typename?: 'MultilingualString'
+                                language: string | null | undefined
+                                value: string | null | undefined
+                            }>
+                            description: Array<{
+                                __typename?: 'MultilingualString'
+                                language: string | null | undefined
+                                value: string | null | undefined
+                            }>
+                            advice: Array<{
+                                __typename?: 'MultilingualString'
+                                language: string | null | undefined
+                                value: string | null | undefined
+                            }>
+                            validityPeriod:
+                                | {
+                                      __typename?: 'ValidityPeriod'
+                                      startTime: string | null | undefined
+                                      endTime: string | null | undefined
+                                  }
+                                | null
+                                | undefined
+                            infoLinks:
+                                | Array<
+                                      | {
+                                            __typename?: 'infoLink'
+                                            uri: string | null | undefined
+                                            label: string | null | undefined
+                                        }
+                                      | null
+                                      | undefined
+                                  >
+                                | null
+                                | undefined
+                        }
+                      | null
+                      | undefined
+                  >
+                  stopPlace:
+                      | {
+                            __typename?: 'StopPlace'
+                            id: string
+                            description: string | null | undefined
+                            name: string
+                            latitude: number | null | undefined
+                            longitude: number | null | undefined
+                            tariffZones: Array<
+                                | { __typename?: 'TariffZone'; id: string }
+                                | null
+                                | undefined
+                            >
+                        }
+                      | null
+                      | undefined
+              }
+            | null
+            | undefined
+        bikeRentalStation:
+            | {
+                  __typename?: 'BikeRentalStation'
+                  id: string
+                  name: string
+                  networks: Array<string | null | undefined>
+                  bikesAvailable: number | null | undefined
+                  spacesAvailable: number | null | undefined
+                  longitude: number | null | undefined
+                  latitude: number | null | undefined
+              }
+            | null
+            | undefined
+    }
+    interchangeFrom:
+        | {
+              __typename?: 'Interchange'
+              guaranteed: boolean | null | undefined
+              staySeated: boolean | null | undefined
+              maximumWaitTime: number | null | undefined
+              fromServiceJourney:
+                  | { __typename?: 'ServiceJourney'; id: string }
+                  | null
+                  | undefined
+              toServiceJourney:
+                  | { __typename?: 'ServiceJourney'; id: string }
+                  | null
+                  | undefined
+          }
+        | null
+        | undefined
+    interchangeTo:
+        | {
+              __typename?: 'Interchange'
+              guaranteed: boolean | null | undefined
+              staySeated: boolean | null | undefined
+              maximumWaitTime: number | null | undefined
+              fromServiceJourney:
+                  | { __typename?: 'ServiceJourney'; id: string }
+                  | null
+                  | undefined
+              toServiceJourney:
+                  | { __typename?: 'ServiceJourney'; id: string }
+                  | null
+                  | undefined
+          }
+        | null
+        | undefined
+    intermediateEstimatedCalls: Array<{
+        __typename?: 'EstimatedCall'
+        actualArrivalTime: string | null | undefined
+        actualDepartureTime: string | null | undefined
+        aimedArrivalTime: string
+        aimedDepartureTime: string
+        cancellation: boolean
+        date: string | null | undefined
+        expectedDepartureTime: string
+        expectedArrivalTime: string
+        forAlighting: boolean
+        forBoarding: boolean
+        predictionInaccurate: boolean
+        realtime: boolean
+        requestStop: boolean
+        destinationDisplay:
+            | {
+                  __typename?: 'DestinationDisplay'
+                  frontText: string | null | undefined
+              }
+            | null
+            | undefined
+        notices: Array<{
+            __typename?: 'Notice'
+            text: string | null | undefined
+        }>
+        quay:
+            | {
+                  __typename?: 'Quay'
+                  id: string
+                  name: string
+                  description: string | null | undefined
+                  publicCode: string | null | undefined
+                  situations: Array<
+                      | {
+                            __typename?: 'PtSituationElement'
+                            situationNumber: string | null | undefined
+                            reportType: ReportType | null | undefined
+                            summary: Array<{
+                                __typename?: 'MultilingualString'
+                                language: string | null | undefined
+                                value: string | null | undefined
+                            }>
+                            description: Array<{
+                                __typename?: 'MultilingualString'
+                                language: string | null | undefined
+                                value: string | null | undefined
+                            }>
+                            advice: Array<{
+                                __typename?: 'MultilingualString'
+                                language: string | null | undefined
+                                value: string | null | undefined
+                            }>
+                            validityPeriod:
+                                | {
+                                      __typename?: 'ValidityPeriod'
+                                      startTime: string | null | undefined
+                                      endTime: string | null | undefined
+                                  }
+                                | null
+                                | undefined
+                            infoLinks:
+                                | Array<
+                                      | {
+                                            __typename?: 'infoLink'
+                                            uri: string | null | undefined
+                                            label: string | null | undefined
+                                        }
+                                      | null
+                                      | undefined
+                                  >
+                                | null
+                                | undefined
+                        }
+                      | null
+                      | undefined
+                  >
+                  stopPlace:
+                      | {
+                            __typename?: 'StopPlace'
+                            id: string
+                            description: string | null | undefined
+                            name: string
+                            latitude: number | null | undefined
+                            longitude: number | null | undefined
+                            tariffZones: Array<
+                                | { __typename?: 'TariffZone'; id: string }
+                                | null
+                                | undefined
+                            >
+                        }
+                      | null
+                      | undefined
+              }
+            | null
+            | undefined
+        serviceJourney:
+            | {
+                  __typename?: 'ServiceJourney'
+                  id: string
+                  publicCode: string | null | undefined
+                  privateCode: string | null | undefined
+                  journeyPattern:
+                      | {
+                            __typename?: 'JourneyPattern'
+                            line: {
+                                __typename?: 'Line'
+                                description: string | null | undefined
+                                flexibleLineType: string | null | undefined
+                                id: string
+                                name: string | null | undefined
+                                publicCode: string | null | undefined
+                                transportMode: TransportMode | null | undefined
+                                transportSubmode:
+                                    | TransportSubmode
+                                    | null
+                                    | undefined
+                                notices: Array<
+                                    | {
+                                          __typename?: 'Notice'
+                                          text: string | null | undefined
+                                      }
+                                    | null
+                                    | undefined
+                                >
+                            }
+                            notices: Array<
+                                | {
+                                      __typename?: 'Notice'
+                                      text: string | null | undefined
+                                  }
+                                | null
+                                | undefined
+                            >
+                        }
+                      | null
+                      | undefined
+                  notices: Array<
+                      | {
+                            __typename?: 'Notice'
+                            text: string | null | undefined
+                        }
+                      | null
+                      | undefined
+                  >
+              }
+            | null
+            | undefined
+    }>
+    line:
+        | {
+              __typename?: 'Line'
+              description: string | null | undefined
+              flexibleLineType: string | null | undefined
+              id: string
+              name: string | null | undefined
+              publicCode: string | null | undefined
+              transportMode: TransportMode | null | undefined
+              transportSubmode: TransportSubmode | null | undefined
+              notices: Array<
+                  | { __typename?: 'Notice'; text: string | null | undefined }
+                  | null
+                  | undefined
+              >
+          }
+        | null
+        | undefined
+    operator:
+        | {
+              __typename?: 'Operator'
+              id: string
+              name: string
+              url: string | null | undefined
+          }
+        | null
+        | undefined
+    pointsOnLink:
+        | {
+              __typename?: 'PointsOnLink'
+              points: string | null | undefined
+              length: number | null | undefined
+          }
+        | null
+        | undefined
+    serviceJourney:
+        | {
+              __typename?: 'ServiceJourney'
+              id: string
+              publicCode: string | null | undefined
+              privateCode: string | null | undefined
+              journeyPattern:
+                  | {
+                        __typename?: 'JourneyPattern'
+                        line: {
+                            __typename?: 'Line'
+                            description: string | null | undefined
+                            flexibleLineType: string | null | undefined
+                            id: string
+                            name: string | null | undefined
+                            publicCode: string | null | undefined
+                            transportMode: TransportMode | null | undefined
+                            transportSubmode:
+                                | TransportSubmode
+                                | null
+                                | undefined
+                            notices: Array<
+                                | {
+                                      __typename?: 'Notice'
+                                      text: string | null | undefined
+                                  }
+                                | null
+                                | undefined
+                            >
+                        }
+                        notices: Array<
+                            | {
+                                  __typename?: 'Notice'
+                                  text: string | null | undefined
+                              }
+                            | null
+                            | undefined
+                        >
+                    }
+                  | null
+                  | undefined
+              notices: Array<
+                  | { __typename?: 'Notice'; text: string | null | undefined }
+                  | null
+                  | undefined
+              >
+          }
+        | null
+        | undefined
+    situations: Array<{
+        __typename?: 'PtSituationElement'
+        situationNumber: string | null | undefined
+        reportType: ReportType | null | undefined
+        summary: Array<{
+            __typename?: 'MultilingualString'
+            language: string | null | undefined
+            value: string | null | undefined
+        }>
+        description: Array<{
+            __typename?: 'MultilingualString'
+            language: string | null | undefined
+            value: string | null | undefined
+        }>
+        advice: Array<{
+            __typename?: 'MultilingualString'
+            language: string | null | undefined
+            value: string | null | undefined
+        }>
+        validityPeriod:
+            | {
+                  __typename?: 'ValidityPeriod'
+                  startTime: string | null | undefined
+                  endTime: string | null | undefined
+              }
+            | null
+            | undefined
+        infoLinks:
+            | Array<
+                  | {
+                        __typename?: 'infoLink'
+                        uri: string | null | undefined
+                        label: string | null | undefined
+                    }
+                  | null
+                  | undefined
+              >
+            | null
+            | undefined
+    }>
+    toEstimatedCall:
+        | {
+              __typename?: 'EstimatedCall'
+              actualArrivalTime: string | null | undefined
+              actualDepartureTime: string | null | undefined
+              aimedArrivalTime: string
+              aimedDepartureTime: string
+              cancellation: boolean
+              date: string | null | undefined
+              expectedDepartureTime: string
+              expectedArrivalTime: string
+              forAlighting: boolean
+              forBoarding: boolean
+              predictionInaccurate: boolean
+              realtime: boolean
+              requestStop: boolean
+              destinationDisplay:
+                  | {
+                        __typename?: 'DestinationDisplay'
+                        frontText: string | null | undefined
+                    }
+                  | null
+                  | undefined
+              notices: Array<{
+                  __typename?: 'Notice'
+                  text: string | null | undefined
+              }>
+              quay:
+                  | {
+                        __typename?: 'Quay'
+                        id: string
+                        name: string
+                        description: string | null | undefined
+                        publicCode: string | null | undefined
+                        situations: Array<
+                            | {
+                                  __typename?: 'PtSituationElement'
+                                  situationNumber: string | null | undefined
+                                  reportType: ReportType | null | undefined
+                                  summary: Array<{
+                                      __typename?: 'MultilingualString'
+                                      language: string | null | undefined
+                                      value: string | null | undefined
+                                  }>
+                                  description: Array<{
+                                      __typename?: 'MultilingualString'
+                                      language: string | null | undefined
+                                      value: string | null | undefined
+                                  }>
+                                  advice: Array<{
+                                      __typename?: 'MultilingualString'
+                                      language: string | null | undefined
+                                      value: string | null | undefined
+                                  }>
+                                  validityPeriod:
+                                      | {
+                                            __typename?: 'ValidityPeriod'
+                                            startTime: string | null | undefined
+                                            endTime: string | null | undefined
+                                        }
+                                      | null
+                                      | undefined
+                                  infoLinks:
+                                      | Array<
+                                            | {
+                                                  __typename?: 'infoLink'
+                                                  uri: string | null | undefined
+                                                  label:
+                                                      | string
+                                                      | null
+                                                      | undefined
+                                              }
+                                            | null
+                                            | undefined
+                                        >
+                                      | null
+                                      | undefined
+                              }
+                            | null
+                            | undefined
+                        >
+                        stopPlace:
+                            | {
+                                  __typename?: 'StopPlace'
+                                  id: string
+                                  description: string | null | undefined
+                                  name: string
+                                  latitude: number | null | undefined
+                                  longitude: number | null | undefined
+                                  tariffZones: Array<
+                                      | {
+                                            __typename?: 'TariffZone'
+                                            id: string
+                                        }
+                                      | null
+                                      | undefined
+                                  >
+                              }
+                            | null
+                            | undefined
+                    }
+                  | null
+                  | undefined
+              serviceJourney:
+                  | {
+                        __typename?: 'ServiceJourney'
+                        id: string
+                        publicCode: string | null | undefined
+                        privateCode: string | null | undefined
+                        journeyPattern:
+                            | {
+                                  __typename?: 'JourneyPattern'
+                                  line: {
+                                      __typename?: 'Line'
+                                      description: string | null | undefined
+                                      flexibleLineType:
+                                          | string
+                                          | null
+                                          | undefined
+                                      id: string
+                                      name: string | null | undefined
+                                      publicCode: string | null | undefined
+                                      transportMode:
+                                          | TransportMode
+                                          | null
+                                          | undefined
+                                      transportSubmode:
+                                          | TransportSubmode
+                                          | null
+                                          | undefined
+                                      notices: Array<
+                                          | {
+                                                __typename?: 'Notice'
+                                                text: string | null | undefined
+                                            }
+                                          | null
+                                          | undefined
+                                      >
+                                  }
+                                  notices: Array<
+                                      | {
+                                            __typename?: 'Notice'
+                                            text: string | null | undefined
+                                        }
+                                      | null
+                                      | undefined
+                                  >
+                              }
+                            | null
+                            | undefined
+                        notices: Array<
+                            | {
+                                  __typename?: 'Notice'
+                                  text: string | null | undefined
+                              }
+                            | null
+                            | undefined
+                        >
+                    }
+                  | null
+                  | undefined
+          }
+        | null
+        | undefined
+    toPlace: {
+        __typename?: 'Place'
+        name: string | null | undefined
+        latitude: number
+        longitude: number
+        quay:
+            | {
+                  __typename?: 'Quay'
+                  id: string
+                  name: string
+                  description: string | null | undefined
+                  publicCode: string | null | undefined
+                  situations: Array<
+                      | {
+                            __typename?: 'PtSituationElement'
+                            situationNumber: string | null | undefined
+                            reportType: ReportType | null | undefined
+                            summary: Array<{
+                                __typename?: 'MultilingualString'
+                                language: string | null | undefined
+                                value: string | null | undefined
+                            }>
+                            description: Array<{
+                                __typename?: 'MultilingualString'
+                                language: string | null | undefined
+                                value: string | null | undefined
+                            }>
+                            advice: Array<{
+                                __typename?: 'MultilingualString'
+                                language: string | null | undefined
+                                value: string | null | undefined
+                            }>
+                            validityPeriod:
+                                | {
+                                      __typename?: 'ValidityPeriod'
+                                      startTime: string | null | undefined
+                                      endTime: string | null | undefined
+                                  }
+                                | null
+                                | undefined
+                            infoLinks:
+                                | Array<
+                                      | {
+                                            __typename?: 'infoLink'
+                                            uri: string | null | undefined
+                                            label: string | null | undefined
+                                        }
+                                      | null
+                                      | undefined
+                                  >
+                                | null
+                                | undefined
+                        }
+                      | null
+                      | undefined
+                  >
+                  stopPlace:
+                      | {
+                            __typename?: 'StopPlace'
+                            id: string
+                            description: string | null | undefined
+                            name: string
+                            latitude: number | null | undefined
+                            longitude: number | null | undefined
+                            tariffZones: Array<
+                                | { __typename?: 'TariffZone'; id: string }
+                                | null
+                                | undefined
+                            >
+                        }
+                      | null
+                      | undefined
+              }
+            | null
+            | undefined
+        bikeRentalStation:
+            | {
+                  __typename?: 'BikeRentalStation'
+                  id: string
+                  name: string
+                  networks: Array<string | null | undefined>
+                  bikesAvailable: number | null | undefined
+                  spacesAvailable: number | null | undefined
+                  longitude: number | null | undefined
+                  latitude: number | null | undefined
+              }
+            | null
+            | undefined
+    }
+    bookingArrangements:
+        | {
+              __typename?: 'BookingArrangement'
+              bookingMethods:
+                  | Array<BookingMethod | null | undefined>
+                  | null
+                  | undefined
+              bookingNote: string | null | undefined
+              latestBookingTime: string | null | undefined
+              minimumBookingPeriod: string | null | undefined
+              bookWhen: PurchaseWhen | null | undefined
+              bookingContact:
+                  | {
+                        __typename?: 'Contact'
+                        phone: string | null | undefined
+                        url: string | null | undefined
+                    }
+                  | null
+                  | undefined
+          }
+        | null
+        | undefined
+}
+
+export type BookingArrangementFieldsFragment = {
+    __typename?: 'BookingArrangement'
+    bookingMethods: Array<BookingMethod | null | undefined> | null | undefined
+    bookingNote: string | null | undefined
+    latestBookingTime: string | null | undefined
+    minimumBookingPeriod: string | null | undefined
+    bookWhen: PurchaseWhen | null | undefined
+    bookingContact:
+        | {
+              __typename?: 'Contact'
+              phone: string | null | undefined
+              url: string | null | undefined
+          }
+        | null
+        | undefined
+}
+
+export type LineFieldsFragment = {
+    __typename?: 'Line'
+    description: string | null | undefined
+    flexibleLineType: string | null | undefined
+    id: string
+    name: string | null | undefined
+    publicCode: string | null | undefined
+    transportMode: TransportMode | null | undefined
+    transportSubmode: TransportSubmode | null | undefined
+    notices: Array<
+        | { __typename?: 'Notice'; text: string | null | undefined }
+        | null
+        | undefined
+    >
+}
+
+export type NoticeFieldsFragment = {
+    __typename?: 'Notice'
+    text: string | null | undefined
+}
+
+export type PlaceFieldsFragment = {
+    __typename?: 'Place'
+    name: string | null | undefined
+    latitude: number
+    longitude: number
+    quay:
+        | {
+              __typename?: 'Quay'
+              id: string
+              name: string
+              description: string | null | undefined
+              publicCode: string | null | undefined
+              situations: Array<
+                  | {
+                        __typename?: 'PtSituationElement'
+                        situationNumber: string | null | undefined
+                        reportType: ReportType | null | undefined
+                        summary: Array<{
+                            __typename?: 'MultilingualString'
+                            language: string | null | undefined
+                            value: string | null | undefined
+                        }>
+                        description: Array<{
+                            __typename?: 'MultilingualString'
+                            language: string | null | undefined
+                            value: string | null | undefined
+                        }>
+                        advice: Array<{
+                            __typename?: 'MultilingualString'
+                            language: string | null | undefined
+                            value: string | null | undefined
+                        }>
+                        validityPeriod:
+                            | {
+                                  __typename?: 'ValidityPeriod'
+                                  startTime: string | null | undefined
+                                  endTime: string | null | undefined
+                              }
+                            | null
+                            | undefined
+                        infoLinks:
+                            | Array<
+                                  | {
+                                        __typename?: 'infoLink'
+                                        uri: string | null | undefined
+                                        label: string | null | undefined
+                                    }
+                                  | null
+                                  | undefined
+                              >
+                            | null
+                            | undefined
+                    }
+                  | null
+                  | undefined
+              >
+              stopPlace:
+                  | {
+                        __typename?: 'StopPlace'
+                        id: string
+                        description: string | null | undefined
+                        name: string
+                        latitude: number | null | undefined
+                        longitude: number | null | undefined
+                        tariffZones: Array<
+                            | { __typename?: 'TariffZone'; id: string }
+                            | null
+                            | undefined
+                        >
+                    }
+                  | null
+                  | undefined
+          }
+        | null
+        | undefined
+    bikeRentalStation:
+        | {
+              __typename?: 'BikeRentalStation'
+              id: string
+              name: string
+              networks: Array<string | null | undefined>
+              bikesAvailable: number | null | undefined
+              spacesAvailable: number | null | undefined
+              longitude: number | null | undefined
+              latitude: number | null | undefined
+          }
+        | null
+        | undefined
+}
+
+export type QuayFieldsFragment = {
+    __typename?: 'Quay'
+    id: string
+    name: string
+    description: string | null | undefined
+    publicCode: string | null | undefined
+    situations: Array<
+        | {
+              __typename?: 'PtSituationElement'
+              situationNumber: string | null | undefined
+              reportType: ReportType | null | undefined
+              summary: Array<{
+                  __typename?: 'MultilingualString'
+                  language: string | null | undefined
+                  value: string | null | undefined
+              }>
+              description: Array<{
+                  __typename?: 'MultilingualString'
+                  language: string | null | undefined
+                  value: string | null | undefined
+              }>
+              advice: Array<{
+                  __typename?: 'MultilingualString'
+                  language: string | null | undefined
+                  value: string | null | undefined
+              }>
+              validityPeriod:
+                  | {
+                        __typename?: 'ValidityPeriod'
+                        startTime: string | null | undefined
+                        endTime: string | null | undefined
+                    }
+                  | null
+                  | undefined
+              infoLinks:
+                  | Array<
+                        | {
+                              __typename?: 'infoLink'
+                              uri: string | null | undefined
+                              label: string | null | undefined
+                          }
+                        | null
+                        | undefined
+                    >
+                  | null
+                  | undefined
+          }
+        | null
+        | undefined
+    >
+    stopPlace:
+        | {
+              __typename?: 'StopPlace'
+              id: string
+              description: string | null | undefined
+              name: string
+              latitude: number | null | undefined
+              longitude: number | null | undefined
+              tariffZones: Array<
+                  { __typename?: 'TariffZone'; id: string } | null | undefined
+              >
+          }
+        | null
+        | undefined
+}
+
+export type SituationFieldsFragment = {
+    __typename?: 'PtSituationElement'
+    situationNumber: string | null | undefined
+    reportType: ReportType | null | undefined
+    summary: Array<{
+        __typename?: 'MultilingualString'
+        language: string | null | undefined
+        value: string | null | undefined
+    }>
+    description: Array<{
+        __typename?: 'MultilingualString'
+        language: string | null | undefined
+        value: string | null | undefined
+    }>
+    advice: Array<{
+        __typename?: 'MultilingualString'
+        language: string | null | undefined
+        value: string | null | undefined
+    }>
+    validityPeriod:
+        | {
+              __typename?: 'ValidityPeriod'
+              startTime: string | null | undefined
+              endTime: string | null | undefined
+          }
+        | null
+        | undefined
+    infoLinks:
+        | Array<
+              | {
+                    __typename?: 'infoLink'
+                    uri: string | null | undefined
+                    label: string | null | undefined
+                }
+              | null
+              | undefined
+          >
+        | null
+        | undefined
+}
+
+export type StopPlaceFieldsFragment = {
+    __typename?: 'StopPlace'
+    id: string
+    description: string | null | undefined
+    name: string
+    latitude: number | null | undefined
+    longitude: number | null | undefined
+    tariffZones: Array<
+        { __typename?: 'TariffZone'; id: string } | null | undefined
+    >
+}
+
+export type BikeRentalStationFieldsFragment = {
+    __typename?: 'BikeRentalStation'
+    id: string
+    name: string
+    networks: Array<string | null | undefined>
+    bikesAvailable: number | null | undefined
+    spacesAvailable: number | null | undefined
+    longitude: number | null | undefined
+    latitude: number | null | undefined
+}
+
+export type AuthorityFieldsFragment = {
+    __typename?: 'Authority'
+    id: string
+    name: string
+    url: string | null | undefined
+}
+
+export type OperatorFieldsFragment = {
+    __typename?: 'Operator'
+    id: string
+    name: string
+    url: string | null | undefined
+}
+
+export type ServiceJourneyFieldsFragment = {
+    __typename?: 'ServiceJourney'
+    id: string
+    publicCode: string | null | undefined
+    privateCode: string | null | undefined
+    journeyPattern:
+        | {
+              __typename?: 'JourneyPattern'
+              line: {
+                  __typename?: 'Line'
+                  description: string | null | undefined
+                  flexibleLineType: string | null | undefined
+                  id: string
+                  name: string | null | undefined
+                  publicCode: string | null | undefined
+                  transportMode: TransportMode | null | undefined
+                  transportSubmode: TransportSubmode | null | undefined
+                  notices: Array<
+                      | {
+                            __typename?: 'Notice'
+                            text: string | null | undefined
+                        }
+                      | null
+                      | undefined
+                  >
+              }
+              notices: Array<
+                  | { __typename?: 'Notice'; text: string | null | undefined }
+                  | null
+                  | undefined
+              >
+          }
+        | null
+        | undefined
+    notices: Array<
+        | { __typename?: 'Notice'; text: string | null | undefined }
+        | null
+        | undefined
+    >
+}
+
+export type InterchangeFieldsFragment = {
+    __typename?: 'Interchange'
+    guaranteed: boolean | null | undefined
+    staySeated: boolean | null | undefined
+    maximumWaitTime: number | null | undefined
+    fromServiceJourney:
+        | { __typename?: 'ServiceJourney'; id: string }
+        | null
+        | undefined
+    toServiceJourney:
+        | { __typename?: 'ServiceJourney'; id: string }
+        | null
+        | undefined
+}
+
+export type PointsOnLinkFieldsFragment = {
+    __typename?: 'PointsOnLink'
+    points: string | null | undefined
+    length: number | null | undefined
+}
+
+export type EstimatedCallFieldsFragment = {
+    __typename?: 'EstimatedCall'
+    actualArrivalTime: string | null | undefined
+    actualDepartureTime: string | null | undefined
+    aimedArrivalTime: string
+    aimedDepartureTime: string
+    cancellation: boolean
+    date: string | null | undefined
+    expectedDepartureTime: string
+    expectedArrivalTime: string
+    forAlighting: boolean
+    forBoarding: boolean
+    predictionInaccurate: boolean
+    realtime: boolean
+    requestStop: boolean
+    destinationDisplay:
+        | {
+              __typename?: 'DestinationDisplay'
+              frontText: string | null | undefined
+          }
+        | null
+        | undefined
+    notices: Array<{ __typename?: 'Notice'; text: string | null | undefined }>
+    quay:
+        | {
+              __typename?: 'Quay'
+              id: string
+              name: string
+              description: string | null | undefined
+              publicCode: string | null | undefined
+              situations: Array<
+                  | {
+                        __typename?: 'PtSituationElement'
+                        situationNumber: string | null | undefined
+                        reportType: ReportType | null | undefined
+                        summary: Array<{
+                            __typename?: 'MultilingualString'
+                            language: string | null | undefined
+                            value: string | null | undefined
+                        }>
+                        description: Array<{
+                            __typename?: 'MultilingualString'
+                            language: string | null | undefined
+                            value: string | null | undefined
+                        }>
+                        advice: Array<{
+                            __typename?: 'MultilingualString'
+                            language: string | null | undefined
+                            value: string | null | undefined
+                        }>
+                        validityPeriod:
+                            | {
+                                  __typename?: 'ValidityPeriod'
+                                  startTime: string | null | undefined
+                                  endTime: string | null | undefined
+                              }
+                            | null
+                            | undefined
+                        infoLinks:
+                            | Array<
+                                  | {
+                                        __typename?: 'infoLink'
+                                        uri: string | null | undefined
+                                        label: string | null | undefined
+                                    }
+                                  | null
+                                  | undefined
+                              >
+                            | null
+                            | undefined
+                    }
+                  | null
+                  | undefined
+              >
+              stopPlace:
+                  | {
+                        __typename?: 'StopPlace'
+                        id: string
+                        description: string | null | undefined
+                        name: string
+                        latitude: number | null | undefined
+                        longitude: number | null | undefined
+                        tariffZones: Array<
+                            | { __typename?: 'TariffZone'; id: string }
+                            | null
+                            | undefined
+                        >
+                    }
+                  | null
+                  | undefined
+          }
+        | null
+        | undefined
+    serviceJourney:
+        | {
+              __typename?: 'ServiceJourney'
+              id: string
+              publicCode: string | null | undefined
+              privateCode: string | null | undefined
+              journeyPattern:
+                  | {
+                        __typename?: 'JourneyPattern'
+                        line: {
+                            __typename?: 'Line'
+                            description: string | null | undefined
+                            flexibleLineType: string | null | undefined
+                            id: string
+                            name: string | null | undefined
+                            publicCode: string | null | undefined
+                            transportMode: TransportMode | null | undefined
+                            transportSubmode:
+                                | TransportSubmode
+                                | null
+                                | undefined
+                            notices: Array<
+                                | {
+                                      __typename?: 'Notice'
+                                      text: string | null | undefined
+                                  }
+                                | null
+                                | undefined
+                            >
+                        }
+                        notices: Array<
+                            | {
+                                  __typename?: 'Notice'
+                                  text: string | null | undefined
+                              }
+                            | null
+                            | undefined
+                        >
+                    }
+                  | null
+                  | undefined
+              notices: Array<
+                  | { __typename?: 'Notice'; text: string | null | undefined }
+                  | null
+                  | undefined
+              >
+          }
+        | null
+        | undefined
+}

--- a/src/logic/otp2/controller.ts
+++ b/src/logic/otp2/controller.ts
@@ -1,14 +1,7 @@
-import createEnturService, {
-    Authority,
-    GetTripPatternsParams,
-    IntermediateEstimatedCall,
-    Leg,
-    LegMode,
-    Notice,
-    TripPattern,
-} from '@entur/sdk'
-import { Modes, StreetMode } from '@entur/sdk/lib/journeyPlanner/types'
+import { GetTripPatternsParams } from '@entur/sdk'
+import { Mode, Modes, StreetMode } from '@entur/sdk/lib/journeyPlanner/types'
 
+import { request as graphqlRequest } from 'graphql-request'
 import { v4 as uuid } from 'uuid'
 import {
     addDays,
@@ -27,8 +20,15 @@ import {
     RoutingError,
     RoutingErrorCode,
     SearchParams,
+    TripPattern,
+    Authority,
+    IntermediateEstimatedCall,
+    Leg,
+    Notice,
+    TripPatternParsed,
 } from '../../types'
 
+import { isNotNullOrUndefined } from '../../utils/misc'
 import { isValidTransitAlternative } from '../../utils/tripPattern'
 import { parseLeg } from '../../utils/leg'
 import { replaceQuay1ForOsloSWithUnknown } from '../../utils/osloSTrack1Replacer'
@@ -38,22 +38,12 @@ import { GetTripPatternError, RoutingErrorsError } from '../../errors'
 
 import JOURNEY_PLANNER_QUERY from './query'
 import { DEFAULT_MODES, filterModesAndSubModes } from './modes'
+import {
+    GetTripPatternsQuery,
+    GetTripPatternsQueryVariables,
+} from '../../generated/graphql'
 
-const sdk = createEnturService({
-    clientName: 'entur-search',
-    hosts: {
-        journeyPlanner: TRANSIT_HOST_OTP2,
-    },
-})
-
-interface Otp2TripPattern extends TripPattern {
-    systemNotices: {
-        tag: string
-        text: string
-    }[]
-}
-
-interface AdditionalOtp2TripPatternParams {
+interface AdditionalTripPatternParams {
     // searchDate is found on TripPatternParams too, but in our case it
     // is never undefined.
     searchDate: Date
@@ -64,10 +54,10 @@ interface AdditionalOtp2TripPatternParams {
 
 // GetTripPatternsParams is an OTP1 type, we need to tweak it to match OTP2
 type Otp2GetTripPatternParams = Omit<GetTripPatternsParams, 'modes' | 'limit'> &
-    AdditionalOtp2TripPatternParams
+    AdditionalTripPatternParams
 
 interface TransitTripPatterns {
-    tripPatterns: Otp2TripPattern[]
+    tripPatterns: TripPatternParsed[]
     queries: GraphqlQuery[]
     metadata?: Metadata
 }
@@ -75,35 +65,36 @@ interface TransitTripPatterns {
 // There is no point in continuing the search if any of these routing errors
 // are received
 const HOPELESS_ROUTING_ERRORS = [
-    RoutingErrorCode.noTransitConnection,
-    RoutingErrorCode.outsideServicePeriod,
-    RoutingErrorCode.outsideBounds,
-    RoutingErrorCode.locationNotFound,
-    RoutingErrorCode.walkingBetterThanTransit,
-    RoutingErrorCode.systemError,
+    RoutingErrorCode.NoTransitConnection,
+    RoutingErrorCode.OutsideServicePeriod,
+    RoutingErrorCode.OutsideBounds,
+    RoutingErrorCode.LocationNotFound,
+    RoutingErrorCode.WalkingBetterThanTransit,
+    RoutingErrorCode.SystemError,
 ]
 
-function createParseTripPattern(): (rawTripPattern: any) => Otp2TripPattern {
+function createParseTripPattern(): (
+    rawTripPattern: TripPattern,
+) => TripPatternParsed {
     let i = 0
     const sharedId = uuid()
     const baseId = sharedId.substring(0, 23)
     const iterator = parseInt(sharedId.substring(24), 16)
 
-    return (rawTripPattern: any) => {
+    return (rawTripPattern: TripPattern): TripPatternParsed => {
         i++
         const id = `${baseId}-${(iterator + i).toString(16).slice(-12)}`
         return parseTripPattern({ id, ...rawTripPattern })
     }
 }
 
-function parseTripPattern(rawTripPattern: any): Otp2TripPattern {
+function parseTripPattern(
+    rawTripPattern: TripPatternParsed,
+): TripPatternParsed {
     return {
         ...rawTripPattern,
         id: rawTripPattern.id || uuid(),
         legs: rawTripPattern.legs.map(parseLeg),
-        genId: `${new Date().getTime()}:${Math.random()
-            .toString(36)
-            .slice(2, 12)}`,
     }
 }
 
@@ -134,6 +125,7 @@ function getTripPatternsQuery(
     comment: string,
 ): GraphqlQuery {
     return {
+        // @ts-ignore
         query: JOURNEY_PLANNER_QUERY,
         variables: {
             ...getTripPatternsVariables(params),
@@ -163,14 +155,14 @@ function getNoticesFromIntermediateEstimatedCalls(
 ): Notice[] {
     if (!estimatedCalls?.length) return []
     return estimatedCalls
-        .map(({ notices }) => notices || [])
-        .reduce((a, b) => [...a, ...b], [])
+        .flatMap(({ notices }) => notices)
+        .filter((notice): notice is Notice => Boolean(notice.text))
 }
 
 function getNotices(leg: Leg): Notice[] {
-    const notices = [
+    const notices: Notice[] = [
         ...getNoticesFromIntermediateEstimatedCalls(
-            leg.intermediateEstimatedCalls,
+            leg.intermediateEstimatedCalls?.filter(isNotNullOrUndefined) || [],
         ),
         ...(leg.serviceJourney?.notices || []),
         ...(leg.serviceJourney?.journeyPattern?.notices || []),
@@ -178,11 +170,14 @@ function getNotices(leg: Leg): Notice[] {
         ...(leg.fromEstimatedCall?.notices || []),
         ...(leg.toEstimatedCall?.notices || []),
         ...(leg.line?.notices || []),
-    ]
+    ].filter(isNotNullOrUndefined)
     return uniqBy(notices, (notice) => notice.text)
 }
 
-function authorityMapper(authority?: Authority): Authority | undefined {
+function authorityMapper(
+    authority?: Authority | null | undefined,
+): (Authority & { codeSpace: string }) | undefined {
+    if (!authority) return undefined
     const codeSpace = authority?.id.split(':')[0]
     if (!authority || !codeSpace) return undefined
 
@@ -194,7 +189,7 @@ function authorityMapper(authority?: Authority): Authority | undefined {
     }
 }
 
-function legMapper(leg: Leg): Leg {
+function legMapper(leg: Leg): Leg & { notices: Notice[] } {
     return {
         ...leg,
         authority: authorityMapper(leg.authority),
@@ -221,7 +216,7 @@ function verifyRoutingErrors(
 
 async function getAndVerifyTripPatterns(
     params: Otp2GetTripPatternParams,
-): Promise<[Otp2TripPattern[], Metadata | undefined, RoutingError[]]> {
+): Promise<[TripPatternParsed[], Metadata | undefined, RoutingError[]]> {
     const [tripPatterns, metadata, routingErrors] = await getTripPatterns(
         params,
     )
@@ -232,19 +227,18 @@ async function getAndVerifyTripPatterns(
 async function getTripPatterns(
     params: Otp2GetTripPatternParams,
     extraHeaders?: Record<string, string>,
-): Promise<[Otp2TripPattern[], Metadata | undefined, RoutingError[]]> {
-    let res
+): Promise<[TripPatternParsed[], Metadata | undefined, RoutingError[]]> {
+    let res: GetTripPatternsQuery
     try {
-        res = await sdk.queryJourneyPlanner<{
-            trip: {
-                // metadata will be undefined if routingErrors is not empty
-                metadata: Metadata | undefined
-                tripPatterns: any[]
-                routingErrors: RoutingError[]
-            }
-        }>(JOURNEY_PLANNER_QUERY, getTripPatternsVariables(params), {
-            headers: extraHeaders,
-        })
+        res = await graphqlRequest<
+            GetTripPatternsQuery,
+            GetTripPatternsQueryVariables
+        >(
+            `${TRANSIT_HOST_OTP2}/graphql`,
+            JOURNEY_PLANNER_QUERY,
+            getTripPatternsVariables(params),
+            extraHeaders,
+        )
     } catch (error) {
         throw new GetTripPatternError(
             error,
@@ -261,8 +255,11 @@ async function getTripPatterns(
                 legs: pattern.legs.map(legMapper),
             }))
             .map(parse),
-        metadata,
-        routingErrors,
+        (metadata as Metadata) || undefined,
+        routingErrors.map((routingError) => ({
+            ...routingError,
+            inputField: routingError.inputField || null,
+        })) || [],
     ]
 }
 
@@ -277,10 +274,10 @@ function getMinutesBetweenDates(
     return Math.max(min, Math.min(max, diff))
 }
 
-function sortTripPatternsByExpectedTime(
-    tripPatterns: Otp2TripPattern[],
+function sortTripPatternsByExpectedTime<T extends TripPattern>(
+    tripPatterns: T[],
     arriveBy: boolean,
-): Otp2TripPattern[] {
+): T[] {
     // eslint-disable-next-line fp/no-mutating-methods
     return tripPatterns.sort((a, b) => {
         if (arriveBy) return a.expectedEndTime > b.expectedEndTime ? -1 : 1
@@ -297,11 +294,11 @@ function getNextSearchDateFromMetadata(
 }
 
 function combineAndSortFlexibleAndTransitTripPatterns(
-    regularTripPatterns: Otp2TripPattern[],
-    flexibleTripPattern?: Otp2TripPattern,
+    regularTripPatterns: TripPatternParsed[],
+    flexibleTripPattern?: TripPatternParsed,
     nextDateTime?: Date,
     arriveBy = false,
-): Otp2TripPattern[] {
+): TripPatternParsed[] {
     if (!flexibleTripPattern) return regularTripPatterns
 
     const sortedTripPatterns = sortTripPatternsByExpectedTime(
@@ -333,7 +330,7 @@ function combineAndSortFlexibleAndTransitTripPatterns(
 async function searchBeforeFlexible(
     searchDate: Date,
     arriveBy = false,
-    flexibleTripPattern: Otp2TripPattern,
+    flexibleTripPattern: TripPattern,
     searchParams: any,
 ): Promise<TransitTripPatterns> {
     const searchWindow = getMinutesBetweenDates(
@@ -355,7 +352,7 @@ async function searchBeforeFlexible(
     const [transitResultsBeforeFlexible, metadata] =
         await getAndVerifyTripPatterns(nextSearchParams)
 
-    const tripPatterns = transitResultsBeforeFlexible
+    const tripPatterns: TripPatternParsed[] = transitResultsBeforeFlexible
         .filter(isValidTransitAlternative)
         .map(replaceQuay1ForOsloSWithUnknown)
 
@@ -484,7 +481,7 @@ async function searchTransitUntilMaxRetries(
  * be handled separately.
  */
 async function searchFlexible(searchParams: Otp2GetTripPatternParams): Promise<{
-    tripPatterns: Otp2TripPattern[]
+    tripPatterns: TripPatternParsed[]
     queries: GraphqlQuery[]
 }> {
     const getTripPatternsParams: Otp2GetTripPatternParams = {
@@ -503,7 +500,7 @@ async function searchFlexible(searchParams: Otp2GetTripPatternParams): Promise<{
     const [returnedTripPatterns] = await getTripPatterns(getTripPatternsParams)
 
     const tripPatterns = returnedTripPatterns.filter(({ legs }) => {
-        const isFootOnly = legs.length === 1 && legs[0]?.mode === LegMode.FOOT
+        const isFootOnly = legs.length === 1 && legs[0]?.mode === Mode.Foot
         return !isFootOnly
     })
 
@@ -548,7 +545,7 @@ async function searchTaxiFrontBack(
     // no car legs. We therefore filter the results to prevent it from
     // returning results that the normal search also might return.
     const taxiResults = tripPatterns.filter(({ legs }) =>
-        legs.some(({ mode }) => mode === LegMode.CAR),
+        legs.some(({ mode }) => mode === Mode.Car),
     )
 
     return {
@@ -628,10 +625,10 @@ export async function searchTransit(
     // transport from where the traveler wants to start or end the trip. Try to
     // find an option using taxi for those parts instead.
     const noStopsInRangeErrors = routingErrors.filter(
-        ({ code }) => code === RoutingErrorCode.noStopsInRange,
+        ({ code }) => code === RoutingErrorCode.NoStopsInRange,
     )
     const hasStopsInRange = noStopsInRangeErrors.length === 0
-    let taxiTripPatterns: Otp2TripPattern[] = []
+    let taxiTripPatterns: TripPatternParsed[] = []
     if (!hasStopsInRange) {
         const noFromStopInRange = noStopsInRangeErrors.some(
             (e) => e.inputField === 'from',
@@ -672,7 +669,7 @@ export async function searchTransit(
         queries = [...queries, ...beforeFlexibleResult.queries]
     }
 
-    const tripPatterns = [
+    const tripPatterns: TripPatternParsed[] = [
         ...taxiTripPatterns,
         ...combineAndSortFlexibleAndTransitTripPatterns(
             regularTripPatterns,
@@ -753,8 +750,18 @@ export async function searchNonTransit(
              * mode. Especially relevant for bike_rental.
              */
             const candidate = result.find(({ legs }) => {
-                const modeToCheck =
-                    mode === StreetMode.BikeRental ? LegMode.BICYCLE : mode
+                const modeToCheck = ((): Mode => {
+                    switch (mode) {
+                        case StreetMode.Foot:
+                            return Mode.Foot
+                        case StreetMode.Bicycle:
+                            return Mode.Bicycle
+                        case StreetMode.Car:
+                            return Mode.Car
+                        case StreetMode.BikeRental:
+                            return Mode.Bicycle
+                    }
+                })()
 
                 const matchesMode = (leg: Leg): boolean =>
                     leg.mode === modeToCheck
@@ -762,7 +769,7 @@ export async function searchNonTransit(
                 return (
                     legs.some(matchesMode) &&
                     legs.every(
-                        (leg) => leg.mode === LegMode.FOOT || matchesMode(leg),
+                        (leg) => leg.mode === Mode.Foot || matchesMode(leg),
                     )
                 )
             })

--- a/src/logic/otp2/query.ts
+++ b/src/logic/otp2/query.ts
@@ -1,299 +1,297 @@
-function minify(query: string): string {
-    return query.trim().replace(/\s+/g, ' ')
-}
+import { gql } from 'graphql-request'
 
-export default minify(`
-query (
-    $numTripPatterns: Int,
-    $from: Location!,
-    $to: Location!,
-    $dateTime: DateTime!,
-    $arriveBy: Boolean!,
-    $wheelchairAccessible: Boolean!,
-    $modes: Modes!,
-    $walkSpeed: Float,
-    $minimumTransferTime: Int,
-    $banned: InputBanned,
-    $whiteListed: InputWhiteListed,
-    $debugItineraryFilter: Boolean,
-    $searchWindow: Int,
-) {
-    trip(
-        numTripPatterns: $numTripPatterns,
-        from: $from,
-        to: $to,
-        dateTime: $dateTime,
-        arriveBy: $arriveBy,
-        wheelchairAccessible: $wheelchairAccessible,
-        modes: $modes,
-        walkSpeed: $walkSpeed,
-        transferSlack: $minimumTransferTime,
-        banned: $banned,
-        whiteListed: $whiteListed,
-        debugItineraryFilter: $debugItineraryFilter,
-        searchWindow: $searchWindow
+export default gql`
+    query getTripPatterns(
+        $numTripPatterns: Int
+        $from: Location!
+        $to: Location!
+        $dateTime: DateTime!
+        $arriveBy: Boolean!
+        $wheelchairAccessible: Boolean!
+        $modes: Modes!
+        $walkSpeed: Float
+        $minimumTransferTime: Int
+        $banned: InputBanned
+        $whiteListed: InputWhiteListed
+        $debugItineraryFilter: Boolean
+        $searchWindow: Int
     ) {
-        metadata {
-            searchWindowUsed
-            nextDateTime
-            prevDateTime
-        }
-        routingErrors {
-            inputField
-            description
-            code
-        }
-        tripPatterns {
-            generalizedCost
-            startTime
-            endTime
-            expectedStartTime
-            expectedEndTime
-            directDuration
-            duration
-            distance
-            walkDistance
-            systemNotices {
-                tag
-                text
+        trip(
+            numTripPatterns: $numTripPatterns
+            from: $from
+            to: $to
+            dateTime: $dateTime
+            arriveBy: $arriveBy
+            wheelchairAccessible: $wheelchairAccessible
+            modes: $modes
+            walkSpeed: $walkSpeed
+            transferSlack: $minimumTransferTime
+            banned: $banned
+            whiteListed: $whiteListed
+            debugItineraryFilter: $debugItineraryFilter
+            searchWindow: $searchWindow
+        ) {
+            metadata {
+                searchWindowUsed
+                nextDateTime
+                prevDateTime
             }
-            legs {
+            routingErrors {
+                inputField
+                description
+                code
+            }
+            tripPatterns {
                 generalizedCost
-                ...legFields
+                startTime
+                endTime
+                expectedStartTime
+                expectedEndTime
+                directDuration
+                duration
+                distance
+                walkDistance
+                systemNotices {
+                    tag
+                    text
+                }
+                legs {
+                    generalizedCost
+                    ...legFields
+                }
             }
         }
     }
-}
 
-fragment legFields on Leg {
-    aimedEndTime
-    aimedStartTime
-    authority {
-        ...authorityFields
-    }
-    distance
-    directDuration
-    duration
-    expectedEndTime
-    expectedStartTime
-    fromEstimatedCall {
-      ...estimatedCallFields
-    }
-    fromPlace {
-        ...placeFields
-    }
-    interchangeFrom {
-        ...interchangeFields
-    }
-    interchangeTo {
-        ...interchangeFields
-    }
-    intermediateEstimatedCalls {
-        ...estimatedCallFields
-    }
-    line {
-      ...lineFields
-    }
-    mode
-    operator {
-        ...operatorFields
-    }
-    pointsOnLink {
-        ...pointsOnLinkFields
-    }
-    realtime
-    ride
-    rentedBike
-    serviceJourney {
-        ...serviceJourneyFields
-    }
-    situations {
-        ...situationFields
-    }
-    toEstimatedCall {
-      ...estimatedCallFields
-    }
-    toPlace {
-      ...placeFields
-    }
-    transportSubmode
-
-    bookingArrangements {
-        ...bookingArrangementFields
-    }
-}
-
-fragment bookingArrangementFields on BookingArrangement {
-    bookingMethods
-    bookingNote
-    latestBookingTime
-    minimumBookingPeriod
-    bookWhen
-    bookingContact {
-        phone
-        url
-    }
-}
-
-fragment lineFields on Line {
-    description
-    flexibleLineType
-    id
-    name
-    notices {
-        ...noticeFields
-    }
-    publicCode
-    transportMode
-    transportSubmode
-}
-
-fragment noticeFields on Notice {
-    text
-}
-
-fragment placeFields on Place {
-    name
-    latitude
-    longitude
-    quay {
-        ...quayFields
-    }
-    bikeRentalStation {
-        ...bikeRentalStationFields
-    }
-}
-
-fragment quayFields on Quay {
-    id
-    name
-    description
-    publicCode
-    situations {
-        ...situationFields
-    }
-    stopPlace {
-        ...stopPlaceFields
-    }
-}
-
-fragment situationFields on PtSituationElement {
-    situationNumber
-    summary {
-        language
-        value
-    }
-    description {
-        language
-        value
-    }
-    advice {
-        language
-        value
-    }
-    validityPeriod {
-        startTime
-        endTime
-    }
-    reportType
-    infoLinks {
-        uri
-        label
-    }
-}
-
-fragment stopPlaceFields on StopPlace {
-    id
-    description
-    name
-    latitude
-    longitude
-    tariffZones {
-        id
-    }
-}
-
-fragment bikeRentalStationFields on BikeRentalStation {
-    id
-    name
-    networks
-    bikesAvailable
-    spacesAvailable
-    longitude
-    latitude
-}
-
-fragment authorityFields on Authority {
-    id
-    name
-    url
-}
-
-fragment operatorFields on Operator {
-    id
-    name
-    url
-}
-
-fragment serviceJourneyFields on ServiceJourney {
-    id
-    journeyPattern {
+    fragment legFields on Leg {
+        aimedEndTime
+        aimedStartTime
+        authority {
+            ...authorityFields
+        }
+        distance
+        directDuration
+        duration
+        expectedEndTime
+        expectedStartTime
+        fromEstimatedCall {
+            ...estimatedCallFields
+        }
+        fromPlace {
+            ...placeFields
+        }
+        interchangeFrom {
+            ...interchangeFields
+        }
+        interchangeTo {
+            ...interchangeFields
+        }
+        intermediateEstimatedCalls {
+            ...estimatedCallFields
+        }
         line {
             ...lineFields
+        }
+        mode
+        operator {
+            ...operatorFields
+        }
+        pointsOnLink {
+            ...pointsOnLinkFields
+        }
+        realtime
+        ride
+        rentedBike
+        serviceJourney {
+            ...serviceJourneyFields
+        }
+        situations {
+            ...situationFields
+        }
+        toEstimatedCall {
+            ...estimatedCallFields
+        }
+        toPlace {
+            ...placeFields
+        }
+        transportSubmode
+
+        bookingArrangements {
+            ...bookingArrangementFields
+        }
+    }
+
+    fragment bookingArrangementFields on BookingArrangement {
+        bookingMethods
+        bookingNote
+        latestBookingTime
+        minimumBookingPeriod
+        bookWhen
+        bookingContact {
+            phone
+            url
+        }
+    }
+
+    fragment lineFields on Line {
+        description
+        flexibleLineType
+        id
+        name
+        notices {
+            ...noticeFields
+        }
+        publicCode
+        transportMode
+        transportSubmode
+    }
+
+    fragment noticeFields on Notice {
+        text
+    }
+
+    fragment placeFields on Place {
+        name
+        latitude
+        longitude
+        quay {
+            ...quayFields
+        }
+        bikeRentalStation {
+            ...bikeRentalStationFields
+        }
+    }
+
+    fragment quayFields on Quay {
+        id
+        name
+        description
+        publicCode
+        situations {
+            ...situationFields
+        }
+        stopPlace {
+            ...stopPlaceFields
+        }
+    }
+
+    fragment situationFields on PtSituationElement {
+        situationNumber
+        summary {
+            language
+            value
+        }
+        description {
+            language
+            value
+        }
+        advice {
+            language
+            value
+        }
+        validityPeriod {
+            startTime
+            endTime
+        }
+        reportType
+        infoLinks {
+            uri
+            label
+        }
+    }
+
+    fragment stopPlaceFields on StopPlace {
+        id
+        description
+        name
+        latitude
+        longitude
+        tariffZones {
+            id
+        }
+    }
+
+    fragment bikeRentalStationFields on BikeRentalStation {
+        id
+        name
+        networks
+        bikesAvailable
+        spacesAvailable
+        longitude
+        latitude
+    }
+
+    fragment authorityFields on Authority {
+        id
+        name
+        url
+    }
+
+    fragment operatorFields on Operator {
+        id
+        name
+        url
+    }
+
+    fragment serviceJourneyFields on ServiceJourney {
+        id
+        journeyPattern {
+            line {
+                ...lineFields
+            }
+            notices {
+                ...noticeFields
+            }
         }
         notices {
             ...noticeFields
         }
+        publicCode
+        privateCode
     }
-    notices {
-        ...noticeFields
-    }
-    publicCode
-    privateCode
-}
 
-fragment interchangeFields on Interchange {
-    guaranteed
-    staySeated
-    maximumWaitTime
-    fromServiceJourney {
-        id
+    fragment interchangeFields on Interchange {
+        guaranteed
+        staySeated
+        maximumWaitTime
+        fromServiceJourney {
+            id
+        }
+        toServiceJourney {
+            id
+        }
     }
-    toServiceJourney {
-        id
-    }
-}
 
-fragment pointsOnLinkFields on PointsOnLink {
-    points
-    length
-}
+    fragment pointsOnLinkFields on PointsOnLink {
+        points
+        length
+    }
 
-fragment estimatedCallFields on EstimatedCall {
-    actualArrivalTime
-    actualDepartureTime
-    aimedArrivalTime
-    aimedDepartureTime
-    cancellation
-    date
-    destinationDisplay {
-        frontText
+    fragment estimatedCallFields on EstimatedCall {
+        actualArrivalTime
+        actualDepartureTime
+        aimedArrivalTime
+        aimedDepartureTime
+        cancellation
+        date
+        destinationDisplay {
+            frontText
+        }
+        expectedDepartureTime
+        expectedArrivalTime
+        forAlighting
+        forBoarding
+        notices {
+            ...noticeFields
+        }
+        predictionInaccurate
+        quay {
+            ...quayFields
+        }
+        realtime
+        requestStop
+        serviceJourney {
+            ...serviceJourneyFields
+        }
     }
-    expectedDepartureTime
-    expectedArrivalTime
-    forAlighting
-    forBoarding
-    notices {
-        ...noticeFields
-    }
-    predictionInaccurate
-    quay {
-        ...quayFields
-    }
-    realtime
-    requestStop
-    serviceJourney {
-        ...serviceJourneyFields
-    }
-}
-`)
+`

--- a/src/routes/v1/trip-patterns.ts
+++ b/src/routes/v1/trip-patterns.ts
@@ -2,8 +2,6 @@ import { Router } from 'express'
 import { parseJSON } from 'date-fns'
 import { v4 as uuid } from 'uuid'
 
-import { TripPattern } from '@entur/sdk'
-
 import trace from '../../tracer'
 import { set as cacheSet, get as cacheGet } from '../../cache'
 import {
@@ -13,7 +11,12 @@ import {
 } from '../../errors'
 import { verifyPartnerToken } from '../../auth'
 
-import { RawSearchParams, SearchParams } from '../../types'
+import {
+    RawSearchParams,
+    SearchParams,
+    TripPattern,
+    TripPatternParsed,
+} from '../../types'
 
 import { getAlternativeTripPatterns } from '../../logic/otp1'
 import { updateTripPattern, getExpires } from '../../logic/otp2'
@@ -124,7 +127,7 @@ router.post('/:id/replace-leg', async (req, res, next) => {
 
         let stopTrace = trace('retrieve from cache')
         const [tripPattern, searchParams] = await Promise.all([
-            cacheGet<TripPattern>(`trip-pattern:${id}`),
+            cacheGet<TripPatternParsed>(`trip-pattern:${id}`),
             cacheGet<SearchParams>(
                 `search-params:${deriveSearchParamsId(id)}`,
                 SEARCH_PARAMS_EXPIRE_IN_SECONDS,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,21 @@
-import { TripPattern, Location } from '@entur/sdk'
+import { Location } from '@entur/sdk'
 
 import { Modes } from '@entur/sdk/lib/journeyPlanner/types'
+
+import { GetTripPatternsQuery } from './generated/graphql'
+
+export { RoutingError, RoutingErrorCode } from './generated/graphql'
+
+export type TripPattern = GetTripPatternsQuery['trip']['tripPatterns'][0]
+export type TripPatternParsed = TripPattern & { id: string }
+export type Leg = NonNullable<TripPattern['legs'][0]>
+export type EstimatedCall = NonNullable<Leg['fromEstimatedCall']>
+export type IntermediateEstimatedCall = NonNullable<
+    Leg['intermediateEstimatedCalls'][0]
+>
+export type Notice = NonNullable<IntermediateEstimatedCall['notices'][0]>
+export type Authority = NonNullable<Leg['authority']>
+export type Place = NonNullable<Leg['fromPlace']>
 
 /**
  * The params sent by clients.
@@ -68,36 +83,4 @@ export enum Platform {
     WEB = 'web',
     APP = 'app',
     WIDGET = 'widget',
-}
-
-export enum RoutingErrorCode {
-    // No transit connection was found between the origin and destination withing the operating day or the next day
-    noTransitConnection = 'noTransitConnection',
-
-    // Transit connection was found, but it was outside the search window, see metadata for the next search window
-    noTransitConnectionInSearchWindow = 'noTransitConnectionInSearchWindow',
-
-    // The date specified is outside the range of data currently loaded into the system
-    outsideServicePeriod = 'outsideServicePeriod',
-
-    // The coordinates are outside the bounds of the data currently loaded into the system
-    outsideBounds = 'outsideBounds',
-
-    // The specified location is not close to any streets or transit stops
-    locationNotFound = 'locationNotFound',
-
-    // No stops are reachable from the location specified. You can try searching using a different access or egress mode
-    noStopsInRange = 'noStopsInRange',
-
-    // The origin and destination are so close to each other, that walking is always better, but no direct mode was specified for the search
-    walkingBetterThanTransit = 'walkingBetterThanTransit',
-
-    // An unknown error happened during the search. The details have been logged to the server logs
-    systemError = 'systemError',
-}
-
-export interface RoutingError {
-    code: RoutingErrorCode
-    inputField?: 'dateTime' | 'from' | 'to'
-    description: string
 }

--- a/src/utils/leg.test.ts
+++ b/src/utils/leg.test.ts
@@ -1,24 +1,24 @@
-import { Leg, LegMode, Place } from '@entur/sdk'
-
+import { Leg, Place } from '../types'
+import { Mode } from '../generated/graphql'
 import { parseLeg, isFlexibleLeg, isTransitLeg, isBikeRentalLeg } from './leg'
 
 describe('parseLeg', () => {
     it('should map coach legs to bus legs', () => {
-        const leg = { mode: LegMode.COACH } as Leg
+        const leg = { mode: Mode.Coach } as Leg
 
-        expect(parseLeg(leg).mode).toEqual(LegMode.BUS)
+        expect(parseLeg(leg).mode).toEqual(Mode.Bus)
     })
 
     it('should update the fromPlace name of transit legs', () => {
         const oldName = 'place name'
         const newName = 'quay name'
-        const buildLeg = (mode: LegMode): Leg =>
+        const buildLeg = (mode: Mode): Leg =>
             ({
                 fromPlace: { name: oldName, quay: { name: newName } },
                 mode,
             } as Leg)
-        const nonTransitLeg = buildLeg(LegMode.FOOT)
-        const transitLeg = buildLeg(LegMode.RAIL)
+        const nonTransitLeg = buildLeg(Mode.Foot)
+        const transitLeg = buildLeg(Mode.Rail)
 
         expect(parseLeg(nonTransitLeg).fromPlace.name).toEqual(oldName)
         expect(parseLeg(transitLeg).fromPlace.name).toEqual(newName)
@@ -39,12 +39,12 @@ describe('isFlexibleLeg', () => {
 
 describe('isTransitLeg', () => {
     it('should check if the leg has a transit mode', () => {
-        expect(isTransitLeg({ mode: LegMode.RAIL } as Leg)).toBeTruthy()
-        expect(isTransitLeg({ mode: LegMode.AIR } as Leg)).toBeTruthy()
-        expect(isTransitLeg({ mode: LegMode.FOOT } as Leg)).toBeFalsy()
-        expect(isTransitLeg({ mode: LegMode.BICYCLE } as Leg)).toBeFalsy()
-        expect(isTransitLeg({ mode: LegMode.CAR } as Leg)).toBeFalsy()
-        expect(isTransitLeg({ mode: LegMode.TRAM } as Leg)).toBeTruthy()
+        expect(isTransitLeg({ mode: Mode.Rail } as Leg)).toBeTruthy()
+        expect(isTransitLeg({ mode: Mode.Air } as Leg)).toBeTruthy()
+        expect(isTransitLeg({ mode: Mode.Foot } as Leg)).toBeFalsy()
+        expect(isTransitLeg({ mode: Mode.Bicycle } as Leg)).toBeFalsy()
+        expect(isTransitLeg({ mode: Mode.Car } as Leg)).toBeFalsy()
+        expect(isTransitLeg({ mode: Mode.Tram } as Leg)).toBeTruthy()
     })
 })
 

--- a/src/utils/leg.ts
+++ b/src/utils/leg.ts
@@ -1,4 +1,6 @@
-import { Leg, LegMode } from '@entur/sdk'
+import { Mode } from '../generated/graphql'
+
+import type { Leg } from '../types'
 
 export function parseLeg(leg: Leg): Leg {
     const { fromPlace, fromEstimatedCall } = leg
@@ -17,16 +19,13 @@ export function parseLeg(leg: Leg): Leg {
     return coachLegToBusLeg(parsedLeg)
 }
 
-export function isFlexibleLeg({ line }: Leg): boolean {
-    return line?.flexibleLineType === 'flexibleAreasOnly'
+export function isFlexibleLeg(leg: Leg): boolean {
+    return leg.line?.flexibleLineType === 'flexibleAreasOnly'
 }
 
-export function isTransitLeg({ mode }: Leg): boolean {
-    return (
-        mode !== LegMode.FOOT &&
-        mode !== LegMode.BICYCLE &&
-        mode !== LegMode.CAR
-    )
+export function isTransitLeg(leg: Leg): boolean {
+    const { mode } = leg
+    return mode !== Mode.Foot && mode !== Mode.Bicycle && mode !== Mode.Car
 }
 
 export function isBikeRentalLeg(leg: Leg): boolean {
@@ -41,6 +40,6 @@ export function isBikeRentalLeg(leg: Leg): boolean {
 function coachLegToBusLeg(leg: Leg): Leg {
     return {
         ...leg,
-        mode: leg.mode === LegMode.COACH ? LegMode.BUS : leg.mode,
+        mode: leg.mode === Mode.Coach ? Mode.Bus : leg.mode,
     }
 }

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -1,0 +1,5 @@
+export function isNotNullOrUndefined<T>(
+    thing: T | null | undefined,
+): thing is T {
+    return thing !== null && thing !== undefined
+}

--- a/src/utils/osloSTrack1Replacer.ts
+++ b/src/utils/osloSTrack1Replacer.ts
@@ -1,4 +1,4 @@
-import { TripPattern, Leg, Place } from '@entur/sdk'
+import { TripPattern, Leg, Place } from '../types'
 
 // Yeah, so... in some cases we get Track 1 at Oslo S even if the train departs from God knows where, just not
 // track 1. This makes our customers fairly unhappy, as some of them - strangely enough - do not appreciate running from

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -2,5 +2,11 @@
     "compilerOptions": {
         "strict": true
     },
-    "include": [".eslintrc.js", "./*.js", "./src/**/*.ts", "./scripts/**/*.ts"]
+    "include": [
+        ".eslintrc.js",
+        "./*.js",
+        "./src/**/*.ts",
+        "./scripts/**/*.ts",
+        "types"
+    ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,6 @@
         "noUncheckedIndexedAccess": true,
         "useUnknownInCatchVariables": false
     },
-    "include": ["src/**/*"],
+    "include": ["src/**/*", "types"],
     "exclude": ["node_modules/*"]
 }


### PR DESCRIPTION
This uses generated types from the actual GraphQL query, which makes our code less prone to errors. If the query is  changed, the types will reflect the changes when we run the codegen script. 
We don't have to remember to update the types and write them correctly.