### PR TITLE
Remove legacy isSameDaySearch response field

### DIFF
--- a/src/routes/v1/transit.ts
+++ b/src/routes/v1/transit.ts
@@ -76,7 +76,6 @@ function mapQueries(
 export interface PostTransitResponse {
     tripPatterns: TripPattern[]
     hasFlexibleTripPattern?: boolean
-    isSameDaySearch?: boolean
     nextCursor?: string
     queries?: (GraphqlQuery & { shamash: string })[]
     routingErrors?: RoutingError[]
@@ -175,7 +174,6 @@ router.post<
         res.json({
             tripPatterns,
             hasFlexibleTripPattern,
-            isSameDaySearch: true, // TODO 2020-03-09: Deprecated! For compatibility with v5.2.0 and older app versions we need to keep returning isSameDaySearch for a while. See https://bitbucket.org/enturas/entur-clients/pull-requests/4167
             nextCursor,
             queries: mappedQueries,
         })


### PR DESCRIPTION
This was removed from the clients two years ago, so should be safe to remove now.
https://bitbucket.org/enturas/entur-clients/pull-requests/4167