### PR TITLE
Export req/res types for non-transit

### DIFF
--- a/src/routes/v1/index.ts
+++ b/src/routes/v1/index.ts
@@ -1,6 +1,16 @@
 import { Router } from 'express'
 
-import nonTransitRouter from './non-transit'
+import nonTransitRouter, {
+    /**
+     * Import types so that `unused-exports` won't complain about these.
+     * They need to be exported to be included in type declarations.
+     */
+    /* eslint-disable @typescript-eslint/no-unused-vars */
+    PostNonTransitRequestBody,
+    PostNonTransitResponse,
+    /* eslint-enable @typescript-eslint/no-unused-vars */
+} from './non-transit'
+
 import transitRouter, {
     /**
      * Import types so that `unused-exports` won't complain about these.
@@ -11,6 +21,7 @@ import transitRouter, {
     PostTransitResponse,
     /* eslint-enable @typescript-eslint/no-unused-vars */
 } from './transit'
+
 import tripPatternsRouter from './trip-patterns'
 
 const router = Router()

--- a/src/routes/v1/non-transit.ts
+++ b/src/routes/v1/non-transit.ts
@@ -34,11 +34,17 @@ function getParams(
     }
 }
 
+export type PostNonTransitResponse = Awaited<
+    ReturnType<typeof searchNonTransit>
+>
+
+export type PostNonTransitRequestBody = RawSearchParams
+
 router.post<
     '/',
     Record<string, never>,
-    Awaited<ReturnType<typeof searchNonTransit>>,
-    RawSearchParams
+    PostNonTransitResponse,
+    PostNonTransitRequestBody
 >('/', async (req, res, next) => {
     try {
         const params = getParams(req.body)


### PR DESCRIPTION
This way the client can get hold of the types for the non-transit endpoint also, not only the transit endpoint.