### PR TITLE
Removed deprecated @types/redis packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
                 "@types/lz-string": "^1.3.34",
                 "@types/node": "16.11.6",
                 "@types/node-fetch": "^2.6.1",
-                "@types/redis": "^4.0.10",
                 "@types/semver": "^7.3.9",
                 "@types/uuid": "^8.3.4",
                 "@typescript-eslint/eslint-plugin": "^5.18.0",
@@ -3208,16 +3207,6 @@
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
             "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
-        },
-        "node_modules/@types/redis": {
-            "version": "4.0.11",
-            "resolved": "https://registry.npmjs.org/@types/redis/-/redis-4.0.11.tgz",
-            "integrity": "sha512-bI+gth8La8Wg/QCR1+V1fhrL9+LZUSWfcqpOj2Kc80ZQ4ffbdL173vQd5wovmoV9i071FU9oP2g6etLuEwb6Rg==",
-            "deprecated": "This is a stub types definition. redis provides its own type definitions, so you do not need this installed.",
-            "dev": true,
-            "dependencies": {
-                "redis": "*"
-            }
         },
         "node_modules/@types/semver": {
             "version": "7.3.9",
@@ -15638,15 +15627,6 @@
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
             "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
-        },
-        "@types/redis": {
-            "version": "4.0.11",
-            "resolved": "https://registry.npmjs.org/@types/redis/-/redis-4.0.11.tgz",
-            "integrity": "sha512-bI+gth8La8Wg/QCR1+V1fhrL9+LZUSWfcqpOj2Kc80ZQ4ffbdL173vQd5wovmoV9i071FU9oP2g6etLuEwb6Rg==",
-            "dev": true,
-            "requires": {
-                "redis": "*"
-            }
         },
         "@types/semver": {
             "version": "7.3.9",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
         "@types/lz-string": "^1.3.34",
         "@types/node": "16.11.6",
         "@types/node-fetch": "^2.6.1",
-        "@types/redis": "^4.0.10",
         "@types/semver": "^7.3.9",
         "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.18.0",


### PR DESCRIPTION
Removed deprecated @types/redis packages because this is now provided by the npm redis package itself.