### PR TITLE
Fix GrapghQL query failing when latitude or longitude are undefined

### DIFF
--- a/src/routes/v1/transit.ts
+++ b/src/routes/v1/transit.ts
@@ -22,7 +22,10 @@ import {
 
 import { uniq } from '../../utils/array'
 import { clean } from '../../utils/object'
-import { deriveSearchParamsId } from '../../utils/searchParams'
+import {
+    deriveSearchParamsId,
+    filterCoordinates,
+} from '../../utils/searchParams'
 import { filterModesAndSubModes } from '../../logic/otp2/modes'
 
 import { ENVIRONMENT } from '../../config'
@@ -56,6 +59,8 @@ function getParams(params: RawSearchParams): SearchParams {
 
     return {
         ...params,
+        from: filterCoordinates(params.from),
+        to: filterCoordinates(params.to),
         searchDate,
         initialSearchDate: searchDate,
         modes,

--- a/src/utils/searchParams.ts
+++ b/src/utils/searchParams.ts
@@ -1,3 +1,14 @@
+import { Location } from '@entur/sdk'
+
 export function deriveSearchParamsId(tripPatternId: string): string {
     return tripPatternId.substring(0, 23)
+}
+
+export function filterCoordinates(location: Location): Location {
+    const coordinates = location.coordinates
+
+    if (coordinates && coordinates.latitude && coordinates.longitude)
+        return location
+
+    return { ...location, coordinates: undefined }
 }


### PR DESCRIPTION
filter coordinates if latitude or longitude are not defined