### PR TITLE
Search window and relaxTransitSearchGeneralizedCostAtDestination

### DIFF
--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -3448,6 +3448,9 @@ export type GetTripPatternsQueryVariables = Exact<{
     searchWindow?: InputMaybe<Scalars['Int']>
     walkReluctance?: InputMaybe<Scalars['Float']>
     waitReluctance?: InputMaybe<Scalars['Float']>
+    relaxTransitSearchGeneralizedCostAtDestination?: InputMaybe<
+        Scalars['Float']
+    >
 }>
 
 export type GetTripPatternsQuery = {

--- a/src/logic/otp2/helpers.ts
+++ b/src/logic/otp2/helpers.ts
@@ -43,6 +43,8 @@ export function getQueryVariables({
     walkReluctance: debugWalkReluctance,
     waitReluctance: debugWaitReluctance,
     transferPenalty: debugTransferPenalty,
+    relaxTransitSearchGeneralizedCostAtDestination:
+        debugRelaxTransitSearchGeneralizedCostAtDestination,
 }: SearchParams): GetTripPatternsQueryVariables {
     const { transferPenalty, transferSlack, walkReluctance, waitReluctance } =
         getSearchPresetVariables(searchPreset, minimumTransferTime)
@@ -58,11 +60,13 @@ export function getQueryVariables({
         walkSpeed,
         banned: undefined,
         whiteListed: undefined,
-        searchWindow,
         transferSlack,
         walkReluctance: debugWalkReluctance || walkReluctance,
         waitReluctance: debugWaitReluctance || waitReluctance,
         transferPenalty: debugTransferPenalty || transferPenalty,
+        searchWindow: searchWindow || undefined,
+        relaxTransitSearchGeneralizedCostAtDestination:
+            debugRelaxTransitSearchGeneralizedCostAtDestination || -1,
         debugItineraryFilter,
     }
 }
@@ -72,6 +76,8 @@ interface PresetValues {
     transferSlack?: number
     walkReluctance?: number
     waitReluctance?: number
+    searchWindow?: number
+    relaxTransitSearchGeneralizedCostAtDestination?: number
 }
 
 function getSearchPresetVariables(

--- a/src/logic/otp2/queries/getTripPatterns.query.ts
+++ b/src/logic/otp2/queries/getTripPatterns.query.ts
@@ -36,6 +36,7 @@ export default gql`
         $searchWindow: Int
         $walkReluctance: Float
         $waitReluctance: Float
+        $relaxTransitSearchGeneralizedCostAtDestination: Float
     ) {
         trip(
             numTripPatterns: $numTripPatterns
@@ -54,6 +55,7 @@ export default gql`
             searchWindow: $searchWindow
             walkReluctance: $walkReluctance
             waitReluctance: $waitReluctance
+            relaxTransitSearchGeneralizedCostAtDestination: $relaxTransitSearchGeneralizedCostAtDestination
         ) {
             metadata {
                 searchWindowUsed

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,8 @@ interface DevParams {
     walkReluctance?: number
     waitReluctance?: number
     transferPenalty?: number
+    searchWindow?: number
+    relaxTransitSearchGeneralizedCostAtDestination?: number
 }
 
 /**


### PR DESCRIPTION
Added search window and relaxTransitSearchGeneralizedCostAtDestination to dev settings for testing purposes.

This will be temporary until we implement the options to send in a textfield of overrides travel search for testing purposes