### PR TITLE
ETU-34545 add serviceDate to leg fragment

### DIFF
--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -2092,6 +2092,22 @@ export type LegFieldsFragment = {
                     id: string
                     name: string
                 }>
+                affects: Array<
+                    | { __typename?: 'AffectedLine' }
+                    | { __typename?: 'AffectedServiceJourney' }
+                    | {
+                          __typename?: 'AffectedStopPlace'
+                          stopConditions: Array<StopCondition>
+                          stopPlace: {
+                              __typename?: 'StopPlace'
+                              id: string
+                              name: string
+                          } | null
+                      }
+                    | { __typename?: 'AffectedStopPlaceOnLine' }
+                    | { __typename?: 'AffectedStopPlaceOnServiceJourney' }
+                    | { __typename?: 'AffectedUnknown' }
+                >
             }>
             stopPlace: {
                 __typename?: 'StopPlace'
@@ -2177,6 +2193,22 @@ export type LegFieldsFragment = {
                     id: string
                     name: string
                 }>
+                affects: Array<
+                    | { __typename?: 'AffectedLine' }
+                    | { __typename?: 'AffectedServiceJourney' }
+                    | {
+                          __typename?: 'AffectedStopPlace'
+                          stopConditions: Array<StopCondition>
+                          stopPlace: {
+                              __typename?: 'StopPlace'
+                              id: string
+                              name: string
+                          } | null
+                      }
+                    | { __typename?: 'AffectedStopPlaceOnLine' }
+                    | { __typename?: 'AffectedStopPlaceOnServiceJourney' }
+                    | { __typename?: 'AffectedUnknown' }
+                >
             }>
             stopPlace: {
                 __typename?: 'StopPlace'
@@ -2279,6 +2311,22 @@ export type LegFieldsFragment = {
                     id: string
                     name: string
                 }>
+                affects: Array<
+                    | { __typename?: 'AffectedLine' }
+                    | { __typename?: 'AffectedServiceJourney' }
+                    | {
+                          __typename?: 'AffectedStopPlace'
+                          stopConditions: Array<StopCondition>
+                          stopPlace: {
+                              __typename?: 'StopPlace'
+                              id: string
+                              name: string
+                          } | null
+                      }
+                    | { __typename?: 'AffectedStopPlaceOnLine' }
+                    | { __typename?: 'AffectedStopPlaceOnServiceJourney' }
+                    | { __typename?: 'AffectedUnknown' }
+                >
             }>
             stopPlace: {
                 __typename?: 'StopPlace'
@@ -2427,6 +2475,22 @@ export type LegFieldsFragment = {
             id: string
             name: string
         }>
+        affects: Array<
+            | { __typename?: 'AffectedLine' }
+            | { __typename?: 'AffectedServiceJourney' }
+            | {
+                  __typename?: 'AffectedStopPlace'
+                  stopConditions: Array<StopCondition>
+                  stopPlace: {
+                      __typename?: 'StopPlace'
+                      id: string
+                      name: string
+                  } | null
+              }
+            | { __typename?: 'AffectedStopPlaceOnLine' }
+            | { __typename?: 'AffectedStopPlaceOnServiceJourney' }
+            | { __typename?: 'AffectedUnknown' }
+        >
     }>
     toEstimatedCall: {
         __typename?: 'EstimatedCall'
@@ -2489,6 +2553,22 @@ export type LegFieldsFragment = {
                     id: string
                     name: string
                 }>
+                affects: Array<
+                    | { __typename?: 'AffectedLine' }
+                    | { __typename?: 'AffectedServiceJourney' }
+                    | {
+                          __typename?: 'AffectedStopPlace'
+                          stopConditions: Array<StopCondition>
+                          stopPlace: {
+                              __typename?: 'StopPlace'
+                              id: string
+                              name: string
+                          } | null
+                      }
+                    | { __typename?: 'AffectedStopPlaceOnLine' }
+                    | { __typename?: 'AffectedStopPlaceOnServiceJourney' }
+                    | { __typename?: 'AffectedUnknown' }
+                >
             }>
             stopPlace: {
                 __typename?: 'StopPlace'
@@ -2574,6 +2654,22 @@ export type LegFieldsFragment = {
                     id: string
                     name: string
                 }>
+                affects: Array<
+                    | { __typename?: 'AffectedLine' }
+                    | { __typename?: 'AffectedServiceJourney' }
+                    | {
+                          __typename?: 'AffectedStopPlace'
+                          stopConditions: Array<StopCondition>
+                          stopPlace: {
+                              __typename?: 'StopPlace'
+                              id: string
+                              name: string
+                          } | null
+                      }
+                    | { __typename?: 'AffectedStopPlaceOnLine' }
+                    | { __typename?: 'AffectedStopPlaceOnServiceJourney' }
+                    | { __typename?: 'AffectedUnknown' }
+                >
             }>
             stopPlace: {
                 __typename?: 'StopPlace'
@@ -2706,6 +2802,22 @@ export type PlaceFieldsFragment = {
                 id: string
                 name: string
             }>
+            affects: Array<
+                | { __typename?: 'AffectedLine' }
+                | { __typename?: 'AffectedServiceJourney' }
+                | {
+                      __typename?: 'AffectedStopPlace'
+                      stopConditions: Array<StopCondition>
+                      stopPlace: {
+                          __typename?: 'StopPlace'
+                          id: string
+                          name: string
+                      } | null
+                  }
+                | { __typename?: 'AffectedStopPlaceOnLine' }
+                | { __typename?: 'AffectedStopPlaceOnServiceJourney' }
+                | { __typename?: 'AffectedUnknown' }
+            >
         }>
         stopPlace: {
             __typename?: 'StopPlace'
@@ -2769,6 +2881,22 @@ export type QuayFieldsFragment = {
             id: string
             name: string
         }>
+        affects: Array<
+            | { __typename?: 'AffectedLine' }
+            | { __typename?: 'AffectedServiceJourney' }
+            | {
+                  __typename?: 'AffectedStopPlace'
+                  stopConditions: Array<StopCondition>
+                  stopPlace: {
+                      __typename?: 'StopPlace'
+                      id: string
+                      name: string
+                  } | null
+              }
+            | { __typename?: 'AffectedStopPlaceOnLine' }
+            | { __typename?: 'AffectedStopPlaceOnServiceJourney' }
+            | { __typename?: 'AffectedUnknown' }
+        >
     }>
     stopPlace: {
         __typename?: 'StopPlace'
@@ -2811,6 +2939,22 @@ export type SituationFieldsFragment = {
         label: string | null
     }> | null
     stopPlaces: Array<{ __typename?: 'StopPlace'; id: string; name: string }>
+    affects: Array<
+        | { __typename?: 'AffectedLine' }
+        | { __typename?: 'AffectedServiceJourney' }
+        | {
+              __typename?: 'AffectedStopPlace'
+              stopConditions: Array<StopCondition>
+              stopPlace: {
+                  __typename?: 'StopPlace'
+                  id: string
+                  name: string
+              } | null
+          }
+        | { __typename?: 'AffectedStopPlaceOnLine' }
+        | { __typename?: 'AffectedStopPlaceOnServiceJourney' }
+        | { __typename?: 'AffectedUnknown' }
+    >
 }
 
 export type StopPlaceFieldsFragment = {
@@ -2947,6 +3091,22 @@ export type EstimatedCallFieldsFragment = {
                 id: string
                 name: string
             }>
+            affects: Array<
+                | { __typename?: 'AffectedLine' }
+                | { __typename?: 'AffectedServiceJourney' }
+                | {
+                      __typename?: 'AffectedStopPlace'
+                      stopConditions: Array<StopCondition>
+                      stopPlace: {
+                          __typename?: 'StopPlace'
+                          id: string
+                          name: string
+                      } | null
+                  }
+                | { __typename?: 'AffectedStopPlaceOnLine' }
+                | { __typename?: 'AffectedStopPlaceOnServiceJourney' }
+                | { __typename?: 'AffectedUnknown' }
+            >
         }>
         stopPlace: {
             __typename?: 'StopPlace'
@@ -3097,6 +3257,22 @@ export type GetLegQuery = {
                         id: string
                         name: string
                     }>
+                    affects: Array<
+                        | { __typename?: 'AffectedLine' }
+                        | { __typename?: 'AffectedServiceJourney' }
+                        | {
+                              __typename?: 'AffectedStopPlace'
+                              stopConditions: Array<StopCondition>
+                              stopPlace: {
+                                  __typename?: 'StopPlace'
+                                  id: string
+                                  name: string
+                              } | null
+                          }
+                        | { __typename?: 'AffectedStopPlaceOnLine' }
+                        | { __typename?: 'AffectedStopPlaceOnServiceJourney' }
+                        | { __typename?: 'AffectedUnknown' }
+                    >
                 }>
                 stopPlace: {
                     __typename?: 'StopPlace'
@@ -3185,6 +3361,22 @@ export type GetLegQuery = {
                         id: string
                         name: string
                     }>
+                    affects: Array<
+                        | { __typename?: 'AffectedLine' }
+                        | { __typename?: 'AffectedServiceJourney' }
+                        | {
+                              __typename?: 'AffectedStopPlace'
+                              stopConditions: Array<StopCondition>
+                              stopPlace: {
+                                  __typename?: 'StopPlace'
+                                  id: string
+                                  name: string
+                              } | null
+                          }
+                        | { __typename?: 'AffectedStopPlaceOnLine' }
+                        | { __typename?: 'AffectedStopPlaceOnServiceJourney' }
+                        | { __typename?: 'AffectedUnknown' }
+                    >
                 }>
                 stopPlace: {
                     __typename?: 'StopPlace'
@@ -3299,6 +3491,22 @@ export type GetLegQuery = {
                         id: string
                         name: string
                     }>
+                    affects: Array<
+                        | { __typename?: 'AffectedLine' }
+                        | { __typename?: 'AffectedServiceJourney' }
+                        | {
+                              __typename?: 'AffectedStopPlace'
+                              stopConditions: Array<StopCondition>
+                              stopPlace: {
+                                  __typename?: 'StopPlace'
+                                  id: string
+                                  name: string
+                              } | null
+                          }
+                        | { __typename?: 'AffectedStopPlaceOnLine' }
+                        | { __typename?: 'AffectedStopPlaceOnServiceJourney' }
+                        | { __typename?: 'AffectedUnknown' }
+                    >
                 }>
                 stopPlace: {
                     __typename?: 'StopPlace'
@@ -3453,6 +3661,22 @@ export type GetLegQuery = {
                 id: string
                 name: string
             }>
+            affects: Array<
+                | { __typename?: 'AffectedLine' }
+                | { __typename?: 'AffectedServiceJourney' }
+                | {
+                      __typename?: 'AffectedStopPlace'
+                      stopConditions: Array<StopCondition>
+                      stopPlace: {
+                          __typename?: 'StopPlace'
+                          id: string
+                          name: string
+                      } | null
+                  }
+                | { __typename?: 'AffectedStopPlaceOnLine' }
+                | { __typename?: 'AffectedStopPlaceOnServiceJourney' }
+                | { __typename?: 'AffectedUnknown' }
+            >
         }>
         toEstimatedCall: {
             __typename?: 'EstimatedCall'
@@ -3515,6 +3739,22 @@ export type GetLegQuery = {
                         id: string
                         name: string
                     }>
+                    affects: Array<
+                        | { __typename?: 'AffectedLine' }
+                        | { __typename?: 'AffectedServiceJourney' }
+                        | {
+                              __typename?: 'AffectedStopPlace'
+                              stopConditions: Array<StopCondition>
+                              stopPlace: {
+                                  __typename?: 'StopPlace'
+                                  id: string
+                                  name: string
+                              } | null
+                          }
+                        | { __typename?: 'AffectedStopPlaceOnLine' }
+                        | { __typename?: 'AffectedStopPlaceOnServiceJourney' }
+                        | { __typename?: 'AffectedUnknown' }
+                    >
                 }>
                 stopPlace: {
                     __typename?: 'StopPlace'
@@ -3603,6 +3843,22 @@ export type GetLegQuery = {
                         id: string
                         name: string
                     }>
+                    affects: Array<
+                        | { __typename?: 'AffectedLine' }
+                        | { __typename?: 'AffectedServiceJourney' }
+                        | {
+                              __typename?: 'AffectedStopPlace'
+                              stopConditions: Array<StopCondition>
+                              stopPlace: {
+                                  __typename?: 'StopPlace'
+                                  id: string
+                                  name: string
+                              } | null
+                          }
+                        | { __typename?: 'AffectedStopPlaceOnLine' }
+                        | { __typename?: 'AffectedStopPlaceOnServiceJourney' }
+                        | { __typename?: 'AffectedUnknown' }
+                    >
                 }>
                 stopPlace: {
                     __typename?: 'StopPlace'
@@ -3785,6 +4041,24 @@ export type GetTripPatternsQuery = {
                                 id: string
                                 name: string
                             }>
+                            affects: Array<
+                                | { __typename?: 'AffectedLine' }
+                                | { __typename?: 'AffectedServiceJourney' }
+                                | {
+                                      __typename?: 'AffectedStopPlace'
+                                      stopConditions: Array<StopCondition>
+                                      stopPlace: {
+                                          __typename?: 'StopPlace'
+                                          id: string
+                                          name: string
+                                      } | null
+                                  }
+                                | { __typename?: 'AffectedStopPlaceOnLine' }
+                                | {
+                                      __typename?: 'AffectedStopPlaceOnServiceJourney'
+                                  }
+                                | { __typename?: 'AffectedUnknown' }
+                            >
                         }>
                         stopPlace: {
                             __typename?: 'StopPlace'
@@ -3876,6 +4150,24 @@ export type GetTripPatternsQuery = {
                                 id: string
                                 name: string
                             }>
+                            affects: Array<
+                                | { __typename?: 'AffectedLine' }
+                                | { __typename?: 'AffectedServiceJourney' }
+                                | {
+                                      __typename?: 'AffectedStopPlace'
+                                      stopConditions: Array<StopCondition>
+                                      stopPlace: {
+                                          __typename?: 'StopPlace'
+                                          id: string
+                                          name: string
+                                      } | null
+                                  }
+                                | { __typename?: 'AffectedStopPlaceOnLine' }
+                                | {
+                                      __typename?: 'AffectedStopPlaceOnServiceJourney'
+                                  }
+                                | { __typename?: 'AffectedUnknown' }
+                            >
                         }>
                         stopPlace: {
                             __typename?: 'StopPlace'
@@ -3993,6 +4285,24 @@ export type GetTripPatternsQuery = {
                                 id: string
                                 name: string
                             }>
+                            affects: Array<
+                                | { __typename?: 'AffectedLine' }
+                                | { __typename?: 'AffectedServiceJourney' }
+                                | {
+                                      __typename?: 'AffectedStopPlace'
+                                      stopConditions: Array<StopCondition>
+                                      stopPlace: {
+                                          __typename?: 'StopPlace'
+                                          id: string
+                                          name: string
+                                      } | null
+                                  }
+                                | { __typename?: 'AffectedStopPlaceOnLine' }
+                                | {
+                                      __typename?: 'AffectedStopPlaceOnServiceJourney'
+                                  }
+                                | { __typename?: 'AffectedUnknown' }
+                            >
                         }>
                         stopPlace: {
                             __typename?: 'StopPlace'
@@ -4165,6 +4475,22 @@ export type GetTripPatternsQuery = {
                         id: string
                         name: string
                     }>
+                    affects: Array<
+                        | { __typename?: 'AffectedLine' }
+                        | { __typename?: 'AffectedServiceJourney' }
+                        | {
+                              __typename?: 'AffectedStopPlace'
+                              stopConditions: Array<StopCondition>
+                              stopPlace: {
+                                  __typename?: 'StopPlace'
+                                  id: string
+                                  name: string
+                              } | null
+                          }
+                        | { __typename?: 'AffectedStopPlaceOnLine' }
+                        | { __typename?: 'AffectedStopPlaceOnServiceJourney' }
+                        | { __typename?: 'AffectedUnknown' }
+                    >
                 }>
                 toEstimatedCall: {
                     __typename?: 'EstimatedCall'
@@ -4230,6 +4556,24 @@ export type GetTripPatternsQuery = {
                                 id: string
                                 name: string
                             }>
+                            affects: Array<
+                                | { __typename?: 'AffectedLine' }
+                                | { __typename?: 'AffectedServiceJourney' }
+                                | {
+                                      __typename?: 'AffectedStopPlace'
+                                      stopConditions: Array<StopCondition>
+                                      stopPlace: {
+                                          __typename?: 'StopPlace'
+                                          id: string
+                                          name: string
+                                      } | null
+                                  }
+                                | { __typename?: 'AffectedStopPlaceOnLine' }
+                                | {
+                                      __typename?: 'AffectedStopPlaceOnServiceJourney'
+                                  }
+                                | { __typename?: 'AffectedUnknown' }
+                            >
                         }>
                         stopPlace: {
                             __typename?: 'StopPlace'
@@ -4321,6 +4665,24 @@ export type GetTripPatternsQuery = {
                                 id: string
                                 name: string
                             }>
+                            affects: Array<
+                                | { __typename?: 'AffectedLine' }
+                                | { __typename?: 'AffectedServiceJourney' }
+                                | {
+                                      __typename?: 'AffectedStopPlace'
+                                      stopConditions: Array<StopCondition>
+                                      stopPlace: {
+                                          __typename?: 'StopPlace'
+                                          id: string
+                                          name: string
+                                      } | null
+                                  }
+                                | { __typename?: 'AffectedStopPlaceOnLine' }
+                                | {
+                                      __typename?: 'AffectedStopPlaceOnServiceJourney'
+                                  }
+                                | { __typename?: 'AffectedUnknown' }
+                            >
                         }>
                         stopPlace: {
                             __typename?: 'StopPlace'

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -37,6 +37,56 @@ export enum AbsoluteDirection {
     West = 'west',
 }
 
+export type AffectedLine = {
+    __typename?: 'AffectedLine'
+    line: Maybe<Line>
+}
+
+export type AffectedServiceJourney = {
+    __typename?: 'AffectedServiceJourney'
+    datedServiceJourney: Maybe<DatedServiceJourney>
+    operatingDay: Maybe<Scalars['Date']>
+    serviceJourney: Maybe<ServiceJourney>
+}
+
+export type AffectedStopPlace = {
+    __typename?: 'AffectedStopPlace'
+    quay: Maybe<Quay>
+    stopConditions: Array<StopCondition>
+    stopPlace: Maybe<StopPlace>
+}
+
+export type AffectedStopPlaceOnLine = {
+    __typename?: 'AffectedStopPlaceOnLine'
+    line: Maybe<Line>
+    quay: Maybe<Quay>
+    stopConditions: Array<StopCondition>
+    stopPlace: Maybe<StopPlace>
+}
+
+export type AffectedStopPlaceOnServiceJourney = {
+    __typename?: 'AffectedStopPlaceOnServiceJourney'
+    datedServiceJourney: Maybe<DatedServiceJourney>
+    operatingDay: Maybe<Scalars['Date']>
+    quay: Maybe<Quay>
+    serviceJourney: Maybe<ServiceJourney>
+    stopConditions: Array<StopCondition>
+    stopPlace: Maybe<StopPlace>
+}
+
+export type AffectedUnknown = {
+    __typename?: 'AffectedUnknown'
+    description: Maybe<Scalars['String']>
+}
+
+export type Affects =
+    | AffectedLine
+    | AffectedServiceJourney
+    | AffectedStopPlace
+    | AffectedStopPlaceOnLine
+    | AffectedStopPlaceOnServiceJourney
+    | AffectedUnknown
+
 export enum AlternativeLegsFilter {
     NoFilter = 'noFilter',
     SameAuthority = 'sameAuthority',
@@ -716,34 +766,49 @@ export type PtSituationElement = {
     __typename?: 'PtSituationElement'
     /** Advice of situation in all different translations available */
     advice: Array<MultilingualString>
-    /** Get affected authority for this situation element */
+    /** Get all affected entities for the situation */
+    affects: Array<Affects>
+    /**
+     * Get affected authority for this situation element
+     * @deprecated Use affects instead
+     */
     authority: Maybe<Authority>
+    /** Timestamp for when the situation was created. */
+    creationTime: Maybe<Scalars['DateTime']>
     /** Description of situation in all different translations available */
     description: Array<MultilingualString>
     id: Scalars['ID']
     /** Optional links to more information. */
     infoLinks: Maybe<Array<InfoLink>>
+    /** @deprecated Use affects instead */
     lines: Array<Maybe<Line>>
+    /** Codespace of the data source. */
+    participant: Maybe<Scalars['String']>
     /** Priority of this situation  */
     priority: Maybe<Scalars['Int']>
+    /** @deprecated Use affects instead */
     quays: Array<Quay>
     /**
-     * Authority that reported this situation
+     * Authority that reported this situation. Always returns the first agency in the codespace
      * @deprecated Not yet officially supported. May be removed or renamed.
      */
     reportAuthority: Maybe<Authority>
     /** ReportType of this situation */
     reportType: Maybe<ReportType>
+    /** @deprecated Use affects instead */
     serviceJourneys: Array<Maybe<ServiceJourney>>
     /** Severity of this situation  */
     severity: Maybe<Severity>
     /** Operator's internal id for this situation */
     situationNumber: Maybe<Scalars['String']>
+    /** @deprecated Use affects instead */
     stopPlaces: Array<StopPlace>
     /** Summary of situation in all different translations available */
     summary: Array<MultilingualString>
     /** Period this situation is in effect */
     validityPeriod: Maybe<ValidityPeriod>
+    /** Timestamp when the situation element was updated. */
+    versionedAtTime: Maybe<Scalars['DateTime']>
 }
 
 export enum PurchaseWhen {
@@ -874,10 +939,7 @@ export type QueryType = {
     stopPlacesByBbox: Array<Maybe<StopPlace>>
     /** Input type for executing a travel search for a trip between two locations. Returns trip patterns describing suggested alternatives for the trip. */
     trip: Trip
-    /**
-     * Input type for executing a travel search for a trip between three or more locations. Returns trip patterns describing suggested alternatives for the trip.
-     * @deprecated This API is under development, expect the contract to change
-     */
+    /** Via trip search. Find trip patterns traveling via one or more intermediate (via) locations. */
     viaTrip: ViaTrip
 }
 
@@ -1005,7 +1067,7 @@ export type QueryTypeSituationArgs = {
 }
 
 export type QueryTypeSituationsArgs = {
-    authorities?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+    codespaces?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
     severities?: InputMaybe<Array<InputMaybe<Severity>>>
 }
 
@@ -1039,11 +1101,14 @@ export type QueryTypeTripArgs = {
     dateTime?: InputMaybe<Scalars['DateTime']>
     debugItineraryFilter?: InputMaybe<Scalars['Boolean']>
     extraSearchCoachReluctance?: InputMaybe<Scalars['Float']>
+    filters?: InputMaybe<Array<TripFilterInput>>
     from: Location
     ignoreRealtimeUpdates?: InputMaybe<Scalars['Boolean']>
     includePlannedCancellations?: InputMaybe<Scalars['Boolean']>
+    includeRealtimeCancellations?: InputMaybe<Scalars['Boolean']>
     itineraryFilters?: InputMaybe<ItineraryFilters>
     locale?: InputMaybe<Locale>
+    maxAccessEgressDurationForMode?: InputMaybe<Array<StreetModeDurationInput>>
     maximumAdditionalTransfers?: InputMaybe<Scalars['Int']>
     maximumTransfers?: InputMaybe<Scalars['Int']>
     modes?: InputMaybe<Modes>
@@ -1073,9 +1138,9 @@ export type QueryTypeViaTripArgs = {
     numTripPatterns?: InputMaybe<Scalars['Int']>
     pageCursor?: InputMaybe<Scalars['String']>
     searchWindow: Scalars['Duration']
+    segments?: InputMaybe<Array<ViaSegmentInput>>
     to: Location
-    viaLocations: Array<ViaLocation>
-    viaRequests?: InputMaybe<Array<ViaRequest>>
+    via: Array<ViaLocationInput>
     wheelchairAccessible?: InputMaybe<Scalars['Boolean']>
 }
 
@@ -1369,6 +1434,19 @@ export enum Severity {
     VerySlight = 'verySlight',
 }
 
+export enum StopCondition {
+    /** Situation applies when stop is the destination of the leg. */
+    Destination = 'destination',
+    /** Situation applies when transfering to another leg at the stop. */
+    ExceptionalStop = 'exceptionalStop',
+    /** Situation applies when passing the stop, without stopping. */
+    NotStopping = 'notStopping',
+    /** Situation applies when at the stop, and the stop requires a request to stop. */
+    RequestStop = 'requestStop',
+    /** Situation applies when stop is the startpoint of the leg. */
+    StartPoint = 'startPoint',
+}
+
 /** Named place where public transport may be accessed. May be a building complex (e.g. a station) or an on-street location. */
 export type StopPlace = PlaceInterface & {
     __typename?: 'StopPlace'
@@ -1447,6 +1525,22 @@ export enum StreetMode {
     Foot = 'foot',
     /** Walk to a scooter rental point, ride a scooter to a scooter rental drop-off point, and walk the rest of the way. This can include scooter rental at fixed locations or free-floating services. */
     ScooterRental = 'scooter_rental',
+}
+
+/** A combination of street mode and corresponding duration */
+export type StreetModeDurationInput = {
+    duration: Scalars['Duration']
+    streetMode: StreetMode
+}
+
+/** Input format for specifying which modes will be allowed for this search. If this element is not present, it will default to all to foot. */
+export type StreetModes = {
+    /** The mode used to get from the origin to the access stops in the transit network the transit network (first-mile). If the element is not present or null,only transit that can be immediately boarded from the origin will be used. */
+    accessMode: InputMaybe<StreetMode>
+    /** The mode used to get from the origin to the destination directly, without using the transit network. If the element is not present or null,direct travel without using transit will be disallowed. */
+    directMode: InputMaybe<StreetMode>
+    /** The mode used to get from the egress stops in the transit network tothe destination (last-mile). If the element is not present or null,only transit that can immediately arrive at the origin will be used. */
+    egressMode: InputMaybe<StreetMode>
 }
 
 /** A system notice is used to tag elements with system information for debugging or other system related purpose. One use-case is to run a routing search with 'itineraryFilters.debug: true'. This will then tag itineraries instead of removing them from the result. This make it possible to inspect the itinerary-filter-chain. A SystemNotice only have english text, because the primary user are technical staff, like testers and developers. */
@@ -1709,6 +1803,28 @@ export type TripMessageStringsArgs = {
     language?: InputMaybe<Scalars['String']>
 }
 
+/** A collection of selectors for what lines/trips should be included in / excluded from search */
+export type TripFilterInput = {
+    /** A list of selectors for what lines/trips should be excluded during the search. If line/trip matches with at least one selector it will be excluded. */
+    not: InputMaybe<Array<TripFilterSelectInput>>
+    /** A list of selectors for what lines/trips should be allowed during search. In order to be accepted a trip/line has to match with at least one selector. An empty list means that everything should be allowed.  */
+    select: InputMaybe<Array<TripFilterSelectInput>>
+}
+
+/** A list of selectors for filter allow-list / exclude-list. An empty list means that everything is allowed. A trip/line will match with selectors if it matches with all non-empty lists. The `select` is always applied first, then `not`. If only `not` not is present, the exclude is applied to the existing set of lines.  */
+export type TripFilterSelectInput = {
+    /** Set of ids for authorities that should be included in/excluded from search */
+    authorities: InputMaybe<Array<Scalars['ID']>>
+    /** Set of ids for group of lines that should be included in/excluded from the search */
+    groupOfLines: InputMaybe<Array<Scalars['ID']>>
+    /** Set of ids for lines that should be included in/excluded from search */
+    lines: InputMaybe<Array<Scalars['ID']>>
+    /** Set of ids for service journeys that should be included in/excluded from search */
+    serviceJourneys: InputMaybe<Array<Scalars['ID']>>
+    /** The allowed modes for the transit part of the trip. Use an empty list to disallow transit for this search. If the element is not present or null, it will default to all transport modes. */
+    transportModes: InputMaybe<Array<TransportModes>>
+}
+
 /** List of legs constituting a suggested sequence of rides and links for a specific trip. */
 export type TripPattern = {
     __typename?: 'TripPattern'
@@ -1786,8 +1902,17 @@ export enum VertexType {
     Transit = 'transit',
 }
 
-/** Input format for specifying a location through either a place reference (id), coordinates or both. If both place and coordinates are provided the place ref will be used if found, coordinates will only be used if place is not known. */
-export type ViaLocation = {
+/** An acceptable combination of trip patterns between two segments of the via search */
+export type ViaConnection = {
+    __typename?: 'ViaConnection'
+    /** The index of the trip pattern in the segment before the via point */
+    from: Maybe<Scalars['Int']>
+    /** The index of the trip pattern in the segment after the via point */
+    to: Maybe<Scalars['Int']>
+}
+
+/** Input format for specifying a location through either a place reference (id), coordinates or both. If both place and coordinates are provided the place ref will be used if found, coordinates will only be used if place is not known. The location also contain information about the minimum and maximum time the user is willing to stay at the via location. */
+export type ViaLocationInput = {
     /** Coordinates for the location. This can be used alone or as fallback if the place id is not found. */
     coordinates: InputMaybe<InputCoordinates>
     /** The maximum time the user wants to stay in the via location before continuing his journey */
@@ -1800,20 +1925,29 @@ export type ViaLocation = {
     place: InputMaybe<Scalars['String']>
 }
 
-export type ViaRequest = {
-    /** The set of access/egress/direct/transit modes to be used for this search. Note that this only works at the Line level. If individual ServiceJourneys have modes that differ from the Line mode, this will NOT be accounted for. */
-    modes: InputMaybe<Modes>
+export type ViaSegmentInput = {
+    /** A list of filters for which trips should be included. A trip will be included if it matches with at least one filter. An empty list of filters means that all trips should be included. */
+    filters: InputMaybe<Array<TripFilterInput>>
+    /** The set of access/egress/direct modes to be used for this search. */
+    modes: InputMaybe<StreetModes>
 }
 
-/** Description of a travel between three or more places. */
+/** Description of a trip via one or more intermediate locations. For example from A, via B, then C to D. */
 export type ViaTrip = {
     __typename?: 'ViaTrip'
     /** A list of routing errors, and fields which caused them */
     routingErrors: Array<RoutingError>
-    /** A list of lists of which indices of the next segment the trip pattern can be combined with */
-    tripPatternCombinations: Array<Array<Array<Scalars['Int']>>>
-    /** A list of lists of the trip patterns for each segment of the journey */
-    tripPatterns: Array<Array<TripPattern>>
+    /** A list of the acceptable combinations of the trip patterns in this segment and the next segment. */
+    tripPatternCombinations: Array<Array<ViaConnection>>
+    /** A list of segments of the via search. The first segment is from the start location to the first entry in the locations list and the last is from the last entry in the locations list to the end location. */
+    tripPatternsPerSegment: Array<ViaTripPatternSegment>
+}
+
+/** A segment of the via search. The first segment is from the start location to the first entry in the locations list and the last is from the last entry in the locations list to the end location. */
+export type ViaTripPatternSegment = {
+    __typename?: 'ViaTripPatternSegment'
+    /** A list of trip patterns for this segment of the search */
+    tripPatterns: Array<TripPattern>
 }
 
 export enum WheelchairBoarding {
@@ -1889,6 +2023,7 @@ export type LegFieldsFragment = {
     realtime: boolean
     ride: boolean
     rentedBike: boolean | null
+    serviceDate: string | null
     transportSubmode: TransportSubmode | null
     authority: {
         __typename?: 'Authority'
@@ -2893,6 +3028,7 @@ export type GetLegQuery = {
         realtime: boolean
         ride: boolean
         rentedBike: boolean | null
+        serviceDate: string | null
         transportSubmode: TransportSubmode | null
         authority: {
             __typename?: 'Authority'
@@ -3577,6 +3713,7 @@ export type GetTripPatternsQuery = {
                 realtime: boolean
                 ride: boolean
                 rentedBike: boolean | null
+                serviceDate: string | null
                 transportSubmode: TransportSubmode | null
                 authority: {
                     __typename?: 'Authority'

--- a/src/logic/otp2/queries/fragments.ts
+++ b/src/logic/otp2/queries/fragments.ts
@@ -48,6 +48,7 @@ export const legFields = gql`
         realtime
         ride
         rentedBike
+        serviceDate
         serviceJourney {
             ...serviceJourneyFields
         }

--- a/src/logic/otp2/queries/fragments.ts
+++ b/src/logic/otp2/queries/fragments.ts
@@ -182,6 +182,15 @@ export const situationsFields = gql`
             id
             name
         }
+        affects {
+            ... on AffectedStopPlace {
+                stopPlace {
+                    id
+                    name
+                }
+                stopConditions
+            }
+        }
     }
 `
 


### PR DESCRIPTION
- also added new `affects` field to `situations`, which replaces the now deprecated `stopPlaces` field
- regenerated graphql types