### PR TITLE
Update leg fix: merge interchange data from old leg

### DIFF
--- a/src/logic/otp2/updateTrip.ts
+++ b/src/logic/otp2/updateTrip.ts
@@ -62,12 +62,18 @@ export async function updateTripPattern(
     const updatedTransitLegs: LegFieldsFragment[] = await Promise.all(
         legs.map((oldLeg) =>
             oldLeg.id
-                ? getLeg(oldLeg.id, extraHeaders, getLegComment).catch(
-                      (error) => {
+                ? getLeg(oldLeg.id, extraHeaders, getLegComment)
+                      .then((newLeg) => ({
+                          ...newLeg,
+                          interchangeTo:
+                              newLeg.interchangeTo || oldLeg.interchangeTo,
+                          interchangeFrom:
+                              newLeg.interchangeFrom || oldLeg.interchangeFrom,
+                      }))
+                      .catch((error) => {
                           logger.warning('Failed to update leg', error)
                           return oldLeg
-                      },
-                  )
+                      })
                 : Promise.resolve(oldLeg),
         ),
     )


### PR DESCRIPTION
JourneyPlanner responds with `interchangeTo: null` in leg query, so try to use old data if no new data available