### PR TITLE
SpikeArrest per user session ID

### DIFF
--- a/api/client-search/apiproxy/policies/spikeArrest.xml
+++ b/api/client-search/apiproxy/policies/spikeArrest.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <SpikeArrest async="false" continueOnError="false" enabled="true" name="spikeArrest">
-  <DisplayName>spikeArrest</DisplayName>
-  <FaultRules/>
-  <Properties/>
-  <Rate>1200pm</Rate>
-  <UseEffectiveCount>false</UseEffectiveCount>
+    <Identifier ref="request.header.x-session-id"/>
+    <DisplayName>spikeArrest</DisplayName>
+    <FaultRules/>
+    <Properties/>
+    <Rate>150pm</Rate>
+    <UseEffectiveCount>true</UseEffectiveCount>
 </SpikeArrest>


### PR DESCRIPTION
- testing in DEV indicates that 50 requests per minute should be plenty, so for PROD we start by setting a conservative limit at 150pm