### PR TITLE
Set cache for updated trip patterns

### DIFF
--- a/src/routes/v1/trip-patterns.ts
+++ b/src/routes/v1/trip-patterns.ts
@@ -269,6 +269,8 @@ router.post<
             extraHeaders,
         )
 
+        await cacheSet(`trip-pattern:${tripPattern.id}`, updatedTripPattern)
+
         res.json({ tripPattern: { ...updatedTripPattern, id: tripPattern.id } })
     } catch (error) {
         next(error)


### PR DESCRIPTION
## Background

We want trip patterns to be accessible for fetching as long as it is being updated.

## Solution

Add it to the cacheSet when updating the trip pattern.